### PR TITLE
Added ability to remote build this snap on all supported architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ _last_py2_res
 .cache
 _trial_temp*
 *.snap
+landscape-client_amd64.txt
+landscape-client_arm64.txt
+landscape-client_ppc64el.txt
+landscape-client_s390x.txt

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,10 @@ snap-install:
 	sudo snap install --devmode landscape-client_0.1_amd64.snap
 .PHONY: snap-install
 
+snap-remote-build:
+	snapcraft --remote-build
+.PHONY: snap-remote-build
+
 snap-remove:
 	sudo snap remove --purge landscape-client
 .PHONY: snap-remove

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,8 +16,7 @@ grade: devel # must be 'stable' to release into candidate/stable channels
 architectures:
   - build-on: amd64
   - build-on: arm64
-  - build-on: ppc64le
-  - build-on: riscv
+  - build-on: ppc64el
   - build-on: s390x
 confinement: strict
 
@@ -56,21 +55,16 @@ parts:
       - libsasl2-modules
       - libsasl2-modules-db
       - libsasl2-modules-gssapi-mit
+      - python3-distutils
       - python3-flake8 
+      - python3-configobj 
       - python3-coverage
-      - python3-twisted 
       - python3-distutils-extra
       - python3-mock 
-      - python3-configobj 
       - python3-netifaces 
       - python3-pycurl 
       - python3-pip
-      - python3-distutils
       - python3-twisted 
-      - python3-mock 
-      - python3-configobj 
-      - python3-netifaces 
-      - python3-pycurl
       - software-properties-common
     override-build: |
       python3 -m venv build/venv --system-site-packages


### PR DESCRIPTION
Added some .gitignore lines to ignore files generated by snapcraft --remote-build, also added a new make target (snap-remote-build) to build on all supported architectures using the Launchpad build farm, and fixed some issues in the snapcraft.yaml file that prevented remote-build from working correctly (duplicate entries for packages and removing riscv)