### PR TITLE
Added a little check to provide a better error (LP: #2027521)

### DIFF
--- a/landscape/lib/logging.py
+++ b/landscape/lib/logging.py
@@ -38,16 +38,22 @@ def init_app_logging(logdir, level="info", progname=None, quiet=False):
     """Given a log dir, set up logging for an application."""
     if progname is None:
         progname = os.path.basename(sys.argv[0])
-    level = logging.getLevelName(level.upper())
-    _init_logging(
-        logging.getLogger(),
-        level,
-        logdir,
-        progname,
-        logging.Formatter(FORMAT),
-        sys.stdout if not quiet else None,
-    )
-    return logging.getLogger()
+    levelcode = logging.getLevelName(level.upper())
+    if isinstance(levelcode, int):
+        _init_logging(
+            logging.getLogger(),
+            levelcode,
+            logdir,
+            progname,
+            logging.Formatter(FORMAT),
+            sys.stdout if not quiet else None,
+        )
+        return logging.getLogger()
+    else:
+        raise AttributeError(
+            f"Unknown level {level!r}, "
+            f"conversion to logging code was {levelcode!r}",
+        )
 
 
 def _init_logging(logger, level, logdir, logname, formatter, stdout=None):


### PR DESCRIPTION
The logging library should provide a better error using "!r" to avoid confusing messages. 

I have added a little check to provide a better error from our side, now the error would look like this:

`AttributeError: Unknown level "'info'", conversion to logging code was "Level 'INFO'"`