### PR TITLE
use --is-registered as systemd service start condition

### DIFF
--- a/debian/landscape-client.service
+++ b/debian/landscape-client.service
@@ -11,6 +11,7 @@ WantedBy=multi-user.target
 [Service]
 Type=simple
 Group=landscape
+ExecCondition=/usr/bin/landscape-config --is-registered
 ExecStart=/usr/bin/landscape-client
 # Don't kill cgroup as child dpkg may restart the service during an upgrade.
 KillMode=process

--- a/debian/rules
+++ b/debian/rules
@@ -23,4 +23,4 @@ override_dh_auto_install:
 	install -D -o root -g root -m 755 apt-update/apt-update $(CURDIR)/$(root_dir)$(LIBDIR)/apt-update
 
 override_dh_installsystemd:
-	dh_installsystemd --no-enable --no-start --no-stop-on-upgrade
+	dh_installsystemd


### PR DESCRIPTION
This re-resolves https://bugs.launchpad.net/ubuntu/+source/landscape-client/+bug/2027613 - see the discussion there regarding the rationale behind this change.