### PR TITLE
use utf-8 for client config file

### DIFF
--- a/landscape/client/configuration.py
+++ b/landscape/client/configuration.py
@@ -107,6 +107,8 @@ class LandscapeSetupConfiguration(BrokerConfiguration):
         "import_from",
     )
 
+    encoding = "utf-8"
+
     def _load_external_options(self):
         """Handle the --import parameter.
 

--- a/landscape/client/tests/test_configuration.py
+++ b/landscape/client/tests/test_configuration.py
@@ -1197,6 +1197,27 @@ url = https://landscape.canonical.com/message-system
         )
 
     @mock.patch("landscape.client.configuration.SysVConfig")
+    def test_silent_setup_unicode_computer_title(self, mock_sysvconfig):
+        """
+        Setup accepts a non-ascii computer title and registration is
+        attempted.
+        """
+        config = self.get_config(["--silent", "-a", "account", "-t", "mélody"])
+        setup(config)
+        mock_sysvconfig().set_start_on_boot.assert_called_once_with(True)
+        mock_sysvconfig().restart_landscape.assert_called_once_with()
+        self.assertConfigEqual(
+            self.get_content(config),
+            f"""\
+[client]
+computer_title = mélody
+data_path = {config.data_path}
+account_name = account
+url = https://landscape.canonical.com/message-system
+""",
+        )
+
+    @mock.patch("landscape.client.configuration.SysVConfig")
     def test_silent_setup_without_computer_title(self, mock_sysvconfig):
         """A computer title is required."""
         config = self.get_config(["--silent", "-a", "account"])

--- a/landscape/lib/config.py
+++ b/landscape/lib/config.py
@@ -242,6 +242,7 @@ class BaseConfiguration:
                 list_values=False,
                 raise_errors=False,
                 write_empty_values=True,
+                encoding=getattr(self, "encoding", None),
             )
         except ConfigObjError as e:
             logger = getLogger()


### PR DESCRIPTION
See https://bugs.launchpad.net/landscape-client/+bug/2028516 for background:

> There's actually no good reason not to accept valid utf-8 as the computer-title. Our message schema declares the title as unicode, and it is stored on the server side as unicode.

> This bug exists because when we write the provided config to /etc/landscape/client.conf we assume the encoding of that file is ASCII. We shouldn't need to make this assumption, and should instead enforce ASCII-ness on a per-field basis (as we do for other types, such as fields that must be integers, etc).