### PR TITLE
pass ssl_public_key settings into pinger to support self-signed cert TLS

### DIFF
--- a/landscape/client/broker/tests/test_ping.py
+++ b/landscape/client/broker/tests/test_ping.py
@@ -16,7 +16,7 @@ class FakePageGetter:
         self.response = response
         self.fetches = []
 
-    def get_page(self, url, post, headers, data):
+    def get_page(self, url, post, headers, data, cainfo=None):
         """
         A method which is supposed to act like a limited version of
         L{landscape.lib.fetch.fetch}.
@@ -27,7 +27,7 @@ class FakePageGetter:
         self.fetches.append((url, post, headers, data))
         return bpickle.dumps(self.response)
 
-    def failing_get_page(self, url, post, headers, data):
+    def failing_get_page(self, url, post, headers, data, cainfo=None):
         """
         A method which is supposed to act like a limited version of
         L{landscape.lib.fetch.fetch}.
@@ -126,8 +126,12 @@ class PingerTest(LandscapeTest):
         super().setUp()
         self.page_getter = FakePageGetter(None)
 
-        def factory(reactor):
-            return PingClient(reactor, get_page=self.page_getter.get_page)
+        def factory(reactor, **kwargs):
+            return PingClient(
+                reactor,
+                get_page=self.page_getter.get_page,
+                **kwargs,
+            )
 
         self.config.ping_url = "http://localhost:8081/whatever"
         self.config.ping_interval = 10


### PR DESCRIPTION
To test:
  1. Run landscape server using a self-signed certificate (landscape-scalable charm bundle should give you this by default)
  2. Make sure `ping_url` is `https`
  3. Run client with `--ssl-public-key=<PATH_TO_PUB_KEY.crt>` or set `ssl_public_key = <PATH_TO_PUB_KEY.crt>` in your .conf
  4. Register your client and make sure it can ping. Easiest way to check is to `tail -f /var/log/haproxy.log | grep ping` on your haproxy unit in the juju model. Make sure the traffic is on port `443`.
  
  If you're having trouble getting the cert from your server to your client, a quick way is:
  ```
  echo -n | openssl s_client -connect <HAPROXY_URL>:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee /etc/landscape/server.crt
  ```

Please also make sure this doesn't break plain HTTP pings.