### PR TITLE
Add optional hostagent_uid field to the message schema.

### DIFF
--- a/README
+++ b/README
@@ -81,10 +81,15 @@ system bus.
 $ sudo ./scripts/landscape-client -c root-client.conf
 ```
 
-Before opening a PR, make sure to run the full testsuite and lint
+Before opening a PR, make sure to run the full test suite and lint:
 ```
 make check3
 make lint
+```
+
+You can run a specific test by running the following (for example):
+```
+python3 -m twisted.trial landscape.client.broker.tests.test_client.BrokerClientTest.test_ping
 ```
 
 ### Building the Landscape Client snap
@@ -158,7 +163,7 @@ $ gnome-keyring-daemon --unlock
 The gnome-keyring-daemon will prompt you (without a prompt) to type in
 the initial unlock password (typically the same password for the account
 you are using - if you are using the default multipass or lxc "ubuntu"
-login, use sudo passwd ubuntu to set it to a known value before doing 
+login, use sudo passwd ubuntu to set it to a known value before doing
 the above step).
 
 Type the login password and hit <ENTER> followed by <CTRL>+D to end

--- a/example.conf
+++ b/example.conf
@@ -198,3 +198,8 @@ script_users = ALL
 #
 # The default is True
 #manage_sources_list_d = True
+
+# Set this for WSL instances managed by Landscape. The value
+# should match the uid assigned to the host machine.
+# For all other computers, do not set this parameter.
+#hostagent_uid = the-uid-of-the-host-machine

--- a/landscape/__init__.py
+++ b/landscape/__init__.py
@@ -22,7 +22,7 @@ DEFAULT_SERVER_API = b"3.2"
 # 3.3:
 #  * Add new schema for the "registration" message, providing Juju information
 #
-SERVER_API = b"3.3"
+SERVER_API = b"3.4"
 
 # The "client-api" field of outgoing messages will be set to this value, and
 # used by the server to know which schema do the message types accepted by the

--- a/landscape/__init__.py
+++ b/landscape/__init__.py
@@ -22,7 +22,7 @@ DEFAULT_SERVER_API = b"3.2"
 # 3.3:
 #  * Add new schema for the "registration" message, providing Juju information
 #
-SERVER_API = b"3.4"
+SERVER_API = b"3.3"
 
 # The "client-api" field of outgoing messages will be set to this value, and
 # used by the server to know which schema do the message types accepted by the

--- a/landscape/client/broker/config.py
+++ b/landscape/client/broker/config.py
@@ -31,6 +31,7 @@ class BrokerConfiguration(Configuration):
               - C{urgent_exchange_interval} (C{1*60})
               - C{http_proxy}
               - C{https_proxy}
+              - C{hostagent_uid}
         """
         parser = super().make_parser()
 
@@ -44,7 +45,7 @@ class BrokerConfiguration(Configuration):
             "-p",
             "--registration-key",
             metavar="KEY",
-            help="The account-wide key used for " "registering clients.",
+            help="The account-wide key used for registering clients.",
         )
         parser.add_option(
             "-t",
@@ -57,14 +58,14 @@ class BrokerConfiguration(Configuration):
             default=15 * 60,
             type="int",
             metavar="INTERVAL",
-            help="The number of seconds between server " "exchanges.",
+            help="The number of seconds between server exchanges.",
         )
         parser.add_option(
             "--urgent-exchange-interval",
             default=1 * 60,
             type="int",
             metavar="INTERVAL",
-            help="The number of seconds between urgent server " "exchanges.",
+            help="The number of seconds between urgent server exchanges.",
         )
         parser.add_option(
             "--ping-interval",
@@ -92,6 +93,12 @@ class BrokerConfiguration(Configuration):
             "--tags",
             help="Comma separated list of tag names to be sent "
             "to the server.",
+        )
+        parser.add_option(
+            "--hostagent-uid",
+            help="Only set this value if this computer is a WSL instance "
+            "managed by Landscape, in which case set it to be the uid that "
+            "Landscape assigned to the host machine.",
         )
 
         return parser

--- a/landscape/client/broker/registration.py
+++ b/landscape/client/broker/registration.py
@@ -76,6 +76,7 @@ class Identity:
     registration_key = config_property("registration_key")
     tags = config_property("tags")
     access_group = config_property("access_group")
+    hostagent_uid = config_property("hostagent_uid")
 
     def __init__(self, config, persist):
         self._config = config
@@ -190,6 +191,7 @@ class RegistrationHandler:
         tags = identity.tags
         group = identity.access_group
         registration_key = identity.registration_key
+        hostagent_uid = identity.hostagent_uid
 
         self._message_store.delete_all_messages()
 
@@ -217,6 +219,8 @@ class RegistrationHandler:
 
         if group:
             message["access_group"] = group
+        if hostagent_uid:
+            message["hostagent_uid"] = hostagent_uid
 
         server_api = self._message_store.get_server_api()
         # If we have juju data to send and if the server is recent enough to

--- a/landscape/client/broker/store.py
+++ b/landscape/client/broker/store.py
@@ -137,8 +137,14 @@ class MessageStore:
     # in case the server supports it.
     _api = DEFAULT_SERVER_API
 
-    def __init__(self, persist, directory, directory_size=1000, max_dirs=4,
-                 max_size_mb=400):
+    def __init__(
+        self,
+        persist,
+        directory,
+        directory_size=1000,
+        max_dirs=4,
+        max_size_mb=400,
+    ):
         self._directory = directory
         self._directory_size = directory_size
         self._max_dirs = max_dirs  # Maximum number of directories in store
@@ -407,7 +413,7 @@ class MessageStore:
             self.add({"type": "resynchronize"})
             self._persist.set("blackhole-messages", True)
             logging.warning(
-                "Unable to succesfully communicate with Landscape server "
+                "Unable to successfully communicate with Landscape server "
                 "for more than a week. Waiting for resync.",
             )
 

--- a/landscape/client/broker/tests/test_config.py
+++ b/landscape/client/broker/tests/test_config.py
@@ -12,7 +12,7 @@ class ConfigurationTests(LandscapeTest):
     def test_loading_sets_http_proxies(self):
         """
         The L{BrokerConfiguration.load} method sets the 'http_proxy' and
-        'https_proxy' enviroment variables to the provided values.
+        'https_proxy' environment variables to the provided values.
         """
         if "http_proxy" in os.environ:
             del os.environ["http_proxy"]
@@ -36,7 +36,7 @@ class ConfigurationTests(LandscapeTest):
     def test_loading_without_http_proxies_does_not_touch_environment(self):
         """
         The L{BrokerConfiguration.load} method doesn't override the
-        'http_proxy' and 'https_proxy' enviroment variables if they
+        'http_proxy' and 'https_proxy' environment variables if they
         are already set and no new value was specified.
         """
         os.environ["http_proxy"] = "heyo"
@@ -71,7 +71,7 @@ class ConfigurationTests(LandscapeTest):
         self.assertEqual(os.environ["https_proxy"], "originals")
 
     def test_default_exchange_intervals(self):
-        """Exchange intervales are set to sane defaults."""
+        """Exchange intervals are set to sane defaults."""
         configuration = BrokerConfiguration()
         self.assertEqual(60, configuration.urgent_exchange_interval)
         self.assertEqual(900, configuration.exchange_interval)
@@ -135,3 +135,27 @@ class ConfigurationTests(LandscapeTest):
             configuration.url,
             "https://landscape.canonical.com/message-system",
         )
+
+    def test_hostagent_uid_handling(self):
+        """
+        The 'hostagent_uid' value specified in the configuration file is
+        passed through.
+        """
+        filename = self.makeFile("[client]\nhostagent_uid = AWESOME COMPUTER")
+
+        configuration = BrokerConfiguration()
+        configuration.load(["--config", filename, "--url", "whatever"])
+
+        self.assertEqual(configuration.hostagent_uid, "AWESOME COMPUTER")
+
+    def test_missing_hostagent_uid_is_none(self):
+        """
+        Test that if we don't explicitly pass a hostagent_uid, then this value
+        is None.
+        """
+        filename = self.makeFile("[client]\n")
+
+        configuration = BrokerConfiguration()
+        configuration.load(["--config", filename, "--url", "whatever"])
+
+        self.assertIsNone(configuration.hostagent_uid)

--- a/landscape/client/broker/tests/test_exchange.py
+++ b/landscape/client/broker/tests/test_exchange.py
@@ -565,7 +565,7 @@ class MessageExchangeTest(LandscapeTest):
         """
         If the server asks for messages that we no longer have, the message
         exchange plugin should send a message to the server indicating that a
-        resynchronization is occuring and then fire a "resynchronize-clients"
+        resynchronization is occurring and then fire a "resynchronize-clients"
         reactor message, so that plugins can generate new data -- if the server
         got out of synch with the client, then we're best off synchronizing
         everything back to it.
@@ -859,7 +859,7 @@ class MessageExchangeTest(LandscapeTest):
         self.reactor.advance(1)
         self.assertEqual(events, [True])
 
-    def test_impending_exchange_gets_reschudeled_with_urgent_reschedule(self):
+    def test_impending_exchange_gets_rescheduled_with_urgent_reschedule(self):
         """
         When an urgent exchange is scheduled after a regular exchange was
         scheduled but before it executed, the old C{impending-exchange} event
@@ -955,7 +955,7 @@ class MessageExchangeTest(LandscapeTest):
         self.wait_for_exchange()
         self.assertFalse(self.transport.payloads)
 
-    def test_stop_twice_doesnt_break(self):
+    def test_stop_twice_does_not_break(self):
         self.exchanger.schedule_exchange()
         self.exchanger.stop()
         self.exchanger.stop()
@@ -1014,7 +1014,7 @@ class MessageExchangeTest(LandscapeTest):
 
     def test_register_message(self):
         """
-        The exchanger expsoses a mechanism for subscribing to messages
+        The exchanger exposes a mechanism for subscribing to messages
         of a particular type.
         """
         messages = []

--- a/landscape/client/broker/tests/test_registration.py
+++ b/landscape/client/broker/tests/test_registration.py
@@ -392,8 +392,8 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         it to the server.
         """
         self.mstore.set_accepted_types(["register"])
-        # hostagent_uid is introduced in the 3.4 message schema
-        self.mstore.set_server_api(b"3.4")
+        # hostagent_uid is introduced in the 3.3 message schema
+        self.mstore.set_server_api(b"3.3")
         self.config.account_name = "account_name"
         self.config.hostagent_uid = "dinosaur computer"
         self.config.tags = "server,london"
@@ -407,8 +407,8 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         a "hostagent_uid" key.
         """
         self.mstore.set_accepted_types(["register"])
-        # hostagent_uid is introduced in the 3.4 message schema
-        self.mstore.set_server_api(b"3.4")
+        # hostagent_uid is introduced in the 3.3 message schema
+        self.mstore.set_server_api(b"3.3")
         self.config.hostagent_uid = ""
         self.reactor.fire("pre-exchange")
         messages = self.mstore.get_pending_messages()
@@ -420,8 +420,8 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         a "hostagent_uid" key.
         """
         self.mstore.set_accepted_types(["register"])
-        # hostagent_uid is introduced in the 3.4 message schema
-        self.mstore.set_server_api(b"3.4")
+        # hostagent_uid is introduced in the 3.3 message schema
+        self.mstore.set_server_api(b"3.3")
         self.config.hostagent_uid = None
         self.reactor.fire("pre-exchange")
         messages = self.mstore.get_pending_messages()

--- a/landscape/client/broker/tests/test_store.py
+++ b/landscape/client/broker/tests/test_store.py
@@ -700,11 +700,11 @@ class MessageStoreTest(LandscapeTest):
         """Messages stop accumulating after one week of not being sent."""
         self.store.record_failure(0)
         self.store.record_failure(7 * 24 * 60 * 60)
-        self.assertIsNot(None, self.store.add({"type": "empty"}))
+        self.assertIsNotNone(self.store.add({"type": "empty"}))
         self.store.record_failure((7 * 24 * 60 * 60) + 1)
-        self.assertIs(None, self.store.add({"type": "empty"}))
+        self.assertIsNone(self.store.add({"type": "empty"}))
         self.assertIn(
-            "WARNING: Unable to succesfully communicate with "
+            "WARNING: Unable to successfully communicate with "
             "Landscape server for more than a week. Waiting for "
             "resync.",
             self.logfile.getvalue(),

--- a/landscape/client/configuration.py
+++ b/landscape/client/configuration.py
@@ -206,7 +206,7 @@ class LandscapeSetupConfiguration(BrokerConfiguration):
             "--include-manager-plugins",
             metavar="PLUGINS",
             default="",
-            help="A comma-separated list of manager plugins to " "load.",
+            help="A comma-separated list of manager plugins to load.",
         )
         parser.add_option(
             "-n",
@@ -230,13 +230,13 @@ class LandscapeSetupConfiguration(BrokerConfiguration):
             "--disable",
             action="store_true",
             default=False,
-            help="Stop running clients and disable start at " "boot.",
+            help="Stop running clients and disable start at boot.",
         )
         parser.add_option(
             "--init",
             action="store_true",
             default=False,
-            help="Set up the client directories structure " "and exit.",
+            help="Set up the client directories structure and exit.",
         )
         parser.add_option(
             "--is-registered",
@@ -567,7 +567,7 @@ def check_account_name_and_password(config):
     if config.silent and not config.no_start:
         if not (config.get("account_name") and config.get("computer_title")):
             raise ConfigurationError(
-                "An account name and computer title are " "required.",
+                "An account name and computer title are required.",
             )
 
 

--- a/landscape/message_schemas/server_bound.py
+++ b/landscape/message_schemas/server_bound.py
@@ -30,7 +30,6 @@ __all__ = [
     "FREE_SPACE",
     "REGISTER",
     "REGISTER_3_3",
-    "REGISTER_3_4",
     "TEMPERATURE",
     "PROCESSOR_INFO",
     "USERS",
@@ -351,49 +350,9 @@ REGISTER_3_3 = Message(
         "access_group": Unicode(),
         "clone_secure_id": Any(Unicode(), Constant(None)),
         "ubuntu_pro_info": Unicode(),
+        "hostagent_uid": Unicode(),
     },
     api=b"3.3",
-    optional=[
-        "registration_password",
-        "hostname",
-        "tags",
-        "vm-info",
-        "container-info",
-        "access_group",
-        "juju-info",
-        "clone_secure_id",
-        "ubuntu_pro_info",
-    ],
-)
-
-
-REGISTER_3_4 = Message(
-    "register",
-    # The term used in the UI is actually 'registration_key', but we keep
-    # the message schema field as 'registration_password' in case a new
-    # client contacts an older server.
-    {
-        "registration_password": Any(Unicode(), Constant(None)),
-        "computer_title": Unicode(),
-        "hostname": Unicode(),
-        "account_name": Unicode(),
-        "tags": Any(Unicode(), Constant(None)),
-        "vm-info": Bytes(),
-        "container-info": Unicode(),
-        "juju-info": KeyDict(
-            {
-                "environment-uuid": Unicode(),
-                "api-addresses": List(Unicode()),
-                "machine-id": Unicode(),
-            },
-        ),
-        "access_group": Unicode(),
-        "clone_secure_id": Any(Unicode(), Constant(None)),
-        "ubuntu_pro_info": Unicode(),
-        "hostagent_uid": Unicode(),
-        # "hostagent_uid": Any(Unicode(), Constant(None)),
-    },
-    api=b"3.4",
     optional=[
         "registration_password",
         "hostname",
@@ -854,7 +813,6 @@ message_schemas = (
     FREE_SPACE,
     REGISTER,
     REGISTER_3_3,
-    REGISTER_3_4,
     TEMPERATURE,
     PROCESSOR_INFO,
     USERS,

--- a/landscape/message_schemas/server_bound.py
+++ b/landscape/message_schemas/server_bound.py
@@ -30,6 +30,7 @@ __all__ = [
     "FREE_SPACE",
     "REGISTER",
     "REGISTER_3_3",
+    "REGISTER_3_4",
     "TEMPERATURE",
     "PROCESSOR_INFO",
     "USERS",
@@ -362,6 +363,48 @@ REGISTER_3_3 = Message(
         "juju-info",
         "clone_secure_id",
         "ubuntu_pro_info",
+    ],
+)
+
+
+REGISTER_3_4 = Message(
+    "register",
+    # The term used in the UI is actually 'registration_key', but we keep
+    # the message schema field as 'registration_password' in case a new
+    # client contacts an older server.
+    {
+        "registration_password": Any(Unicode(), Constant(None)),
+        "computer_title": Unicode(),
+        "hostname": Unicode(),
+        "account_name": Unicode(),
+        "tags": Any(Unicode(), Constant(None)),
+        "vm-info": Bytes(),
+        "container-info": Unicode(),
+        "juju-info": KeyDict(
+            {
+                "environment-uuid": Unicode(),
+                "api-addresses": List(Unicode()),
+                "machine-id": Unicode(),
+            },
+        ),
+        "access_group": Unicode(),
+        "clone_secure_id": Any(Unicode(), Constant(None)),
+        "ubuntu_pro_info": Unicode(),
+        "hostagent_uid": Unicode(),
+        # "hostagent_uid": Any(Unicode(), Constant(None)),
+    },
+    api=b"3.4",
+    optional=[
+        "registration_password",
+        "hostname",
+        "tags",
+        "vm-info",
+        "container-info",
+        "access_group",
+        "juju-info",
+        "clone_secure_id",
+        "ubuntu_pro_info",
+        "hostagent_uid",
     ],
 )
 
@@ -811,6 +854,7 @@ message_schemas = (
     FREE_SPACE,
     REGISTER,
     REGISTER_3_3,
+    REGISTER_3_4,
     TEMPERATURE,
     PROCESSOR_INFO,
     USERS,


### PR DESCRIPTION
Manual Testing Instructions:

1. Get this PR code.
2. Setup a development `landscape-server` instance.
3. Install this code to the instance running server: `./build/venv/bin/pip install "git+https://github.com/wck0/landscape-client.git"`
4. Run the server code.
5. Edit the `landscape-client.conf` file for `landscape-client` to point to your dev server.
6. Add a new line to that same file: `hostagent_uid = some test value`
7. Run the development client: `sudo ./scripts/landscape-client`
8. Wait for it to register with your dev server.
9. Watch the logs or check in `/tmp/landscape/broker.log` that the registration message includes the `hostagent_uid` key with the value you set above and that it is using version 3.4 of the message schema.
10. Verify you can accept the computer as usual.
