### PR TITLE
fix format of architectures in snapcraft.yaml so launchpad likes it

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,12 @@ description: |
   Landscape account.
 
 grade: devel # must be 'stable' to release into candidate/stable channels
-architectures: [amd64, arm64, armhf, ppc64el, s390x]
+architectures:
+  - build-on: [amd64]
+  - build-on: [arm64]
+  - build-on: [armhf]
+  - build-on: [ppc64el]
+  - build-on: [s390x]
 confinement: strict
 
 apps:


### PR DESCRIPTION
prior to this change builds would only happen on amd64. Here's proof that with this change it builds for all listed arches: https://launchpad.net/~mitchburton/+snap/snapcraft-landscape-client-b8bc866f93dd763be09f288a7a444fec