### PR TITLE
fixing inaccuracies with bfree, using bavail instead

### DIFF
--- a/landscape/lib/disk.py
+++ b/landscape/lib/disk.py
@@ -74,7 +74,7 @@ def get_mount_info(
             continue
         block_size = stats.f_bsize
         total_space = (stats.f_blocks * block_size) // megabytes
-        free_space = (stats.f_bfree * block_size) // megabytes
+        free_space = (stats.f_bavail * block_size) // megabytes
         yield {
             "device": device,
             "mount-point": mount_point,


### PR DESCRIPTION
The bfree variable (on ubuntu 22.04, my system) Reports a much higher value than bavail, this conceivably occurs do to some blocks being free, but not available due to block sizes or other values, so the disk plugin does not agree with the `df` command, I'm not sure if that consistency is important to this application, but it's important to me, so thought I'd submit a pull request. 