### PR TITLE
do not call `update-motd` in maintainer scripts

### DIFF
--- a/debian/landscape-common.postinst
+++ b/debian/landscape-common.postinst
@@ -93,14 +93,13 @@ case "$1" in
         if [ "$RET" = "Cache sysinfo in /etc/motd" ]; then
             rm -f $PROFILE_LOCATION 2>/dev/null || true
             ln -sf $WRAPPER $UPDATE_MOTD_LOCATION
-            update-motd 2>/dev/null || true
+            $WRAPPER >/dev/null 2>&1 || true
         elif [ "$RET" = "Run sysinfo on every login" ]; then
             rm -f $UPDATE_MOTD_LOCATION 2>/dev/null || true
-            update-motd 2>/dev/null || true
             ln -sf $WRAPPER $PROFILE_LOCATION
+            $WRAPPER >/dev/null 2>&1 || true
         else
             rm -f $UPDATE_MOTD_LOCATION 2>/dev/null || true
-            update-motd 2>/dev/null || true
             rm -f $PROFILE_LOCATION || true
         fi
 

--- a/debian/landscape-common.prerm
+++ b/debian/landscape-common.prerm
@@ -20,7 +20,6 @@ set -e
 case "$1" in
     remove|upgrade|deconfigure)
        rm -f /etc/update-motd.d/50-landscape-sysinfo 2>/dev/null || true
-       update-motd 2>/dev/null || true
        rm -f /etc/profile.d/landscape-sysinfo.sh 2>/dev/null || true
     ;;
 


### PR DESCRIPTION
d/landscape-common.postint, d/landscape-common.prerm: do not call update-motd when installing/removing landscape-sysinfo.wrapper

See bug reports:
 * https://bugs.launchpad.net/ubuntu/+source/landscape-client/+bug/1855544
 * https://bugs.launchpad.net/ubuntu/+source/landscape-client/+bug/2040924

Prior to this change, output during installation:
```bash
ubuntu@together-hawk:~$ sudo apt install landscape-common
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following NEW packages will be installed:
  landscape-common
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 88.6 kB of archives.
After this operation, 430 kB of additional disk space will be used.
Get:1 http://ppa.launchpad.net/landscape/self-hosted-beta/ubuntu focal/main amd64 landscape-common amd64 23.10+git6308+1-0ubuntu0 [88.6 kB]
Fetched 88.6 kB in 1s (74.9 kB/s)           
Preconfiguring packages ...
Selecting previously unselected package landscape-common.
(Reading database ... 32114 files and directories currently installed.)
Preparing to unpack .../landscape-common_23.10+git6308+1-0ubuntu0_amd64.deb ...
Unpacking landscape-common (23.10+git6308+1-0ubuntu0) ...
Setting up landscape-common (23.10+git6308+1-0ubuntu0) ...
Welcome to Ubuntu 20.04.6 LTS (GNU/Linux 6.2.0-37-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Wed Dec 13 22:32:12 UTC 2023

  System load:  0.75              Temperature:           72.0 C
  Usage of /:   11.7% of 6.12GB   Processes:             33
  Memory usage: 0%                Users logged in:       0
  Swap usage:   0%                IPv4 address for eth0: 10.76.244.112


Expanded Security Maintenance for Applications is not enabled.

0 updates can be applied immediately.

Enable ESM Apps to receive additional future security updates.
See https://ubuntu.com/esm or run: sudo pro status

New release '22.04.3 LTS' available.
Run 'do-release-upgrade' to upgrade to it.


*** System restart required ***
Processing triggers for man-db (2.9.1-1) ...
```

After this change:
```
ubuntu@nice-gecko:~$ sudo apt install ./common.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'landscape-common' instead of './common.deb'
The following package was automatically installed and is no longer required:
  libfreetype6
Use 'sudo apt autoremove' to remove it.
The following packages will be upgraded:
  landscape-common
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/108 kB of archives.
After this operation, 20.5 kB of additional disk space will be used.
Get:1 /home/ubuntu/common.deb landscape-common amd64 23.11-0ubuntu0~test0 [108 kB]
Preconfiguring packages ...          
(Reading database ... 32194 files and directories currently installed.)
Preparing to unpack /home/ubuntu/common.deb ...
Unpacking landscape-common (23.11-0ubuntu0~test0) over (19.12-0ubuntu4.3) ...
Setting up landscape-common (23.11-0ubuntu0~test0) ...
Processing triggers for man-db (2.9.1-1) ...
```

landscape-sysinfo.cache is still created
```bash
ubuntu@nice-gecko:~$ cat /var/lib/landscape/landscape-sysinfo.cache

  System information as of Wed Dec 13 22:38:40 UTC 2023

  System load:  1.34              Temperature:           79.0 C
  Usage of /:   11.7% of 6.12GB   Processes:             31
  Memory usage: 1%                Users logged in:       0
  Swap usage:   0%                IPv4 address for eth0: 10.76.244.15
```