### PR TITLE
Read temperature from hwmon devices

### DIFF
--- a/landscape/client/monitor/tests/test_temperature.py
+++ b/landscape/client/monitor/tests/test_temperature.py
@@ -5,10 +5,10 @@ from unittest import mock
 from landscape.client.monitor.temperature import Temperature
 from landscape.client.tests.helpers import LandscapeTest
 from landscape.client.tests.helpers import MonitorHelper
-from landscape.lib.tests.test_sysstats import ThermalZoneTest
+from landscape.lib.tests.test_sysstats import SysfsThermalZoneTest
 
 
-class TemperatureTestWithSampleData(ThermalZoneTest, LandscapeTest):
+class TemperatureTestWithSampleData(SysfsThermalZoneTest, LandscapeTest):
     """Tests for the temperature plugin."""
 
     helpers = [MonitorHelper]

--- a/landscape/sysinfo/tests/test_temperature.py
+++ b/landscape/sysinfo/tests/test_temperature.py
@@ -1,11 +1,11 @@
 import os
 
-from landscape.lib.tests.test_sysstats import ThermalZoneTest
+from landscape.lib.tests.test_sysstats import HwmonThermalZoneTest
 from landscape.sysinfo.sysinfo import SysInfoPluginRegistry
 from landscape.sysinfo.temperature import Temperature
 
 
-class TemperatureTest(ThermalZoneTest):
+class TemperatureTest(HwmonThermalZoneTest):
     def setUp(self):
         super().setUp()
         self.temperature = Temperature(self.thermal_zone_path)
@@ -16,7 +16,7 @@ class TemperatureTest(ThermalZoneTest):
         self.assertIs(None, self.successResultOf(self.temperature.run()))
 
     def test_run_adds_header(self):
-        self.write_thermal_zone("THM0", "51000")
+        self.write_thermal_zone("THM0", "1", "51000")
         self.temperature.run()
         self.assertEqual(
             self.sysinfo.get_headers(),
@@ -24,8 +24,8 @@ class TemperatureTest(ThermalZoneTest):
         )
 
     def test_ignores_bad_files(self):
-        self.write_thermal_zone("THM0", "")
-        temperature_path = os.path.join(self.thermal_zone_path, "THM0/temp")
+        self.write_thermal_zone("THM0", "1", "")
+        temperature_path = os.path.join(self.base_path, "THM0/temp1_input")
         file = open(temperature_path, "w")
         file.write("bad-label: 51 C")
         file.close()
@@ -33,14 +33,14 @@ class TemperatureTest(ThermalZoneTest):
         self.assertEqual(self.sysinfo.get_headers(), [])
 
     def test_ignores_unknown_formats(self):
-        self.write_thermal_zone("THM0", "FOO")
+        self.write_thermal_zone("THM0", "1", "FOO")
         self.temperature.run()
         self.assertEqual(self.sysinfo.get_headers(), [])
 
     def test_picks_highest_temperature(self):
-        self.write_thermal_zone("THM0", "51000")
-        self.write_thermal_zone("THM1", "53000")
-        self.write_thermal_zone("THM2", "52000")
+        self.write_thermal_zone("THM0", "1", "51000")
+        self.write_thermal_zone("THM0", "2", "53000")
+        self.write_thermal_zone("THM1", "1", "52000")
         self.temperature.run()
         self.assertEqual(
             self.sysinfo.get_headers(),


### PR DESCRIPTION
On most systems `hwmon` provides access to the temperature information on more devices, including the CPU and GPU on most systems. These additional temperature sources yield a more accurate maximum temperature for the overall system.

With this change, the following precedence is used for reading thermal zones (depending on availability):
1. `/sys/class/hwmon/*/temp*_input`
2. `/sys/class/thermal/*/temp`
3. `/proc/acpi/thermal_zone/*/temperature`