### PR TITLE
fix: copy submodules when building the snap

### DIFF
--- a/README
+++ b/README
@@ -58,6 +58,12 @@ Landscape service. There are two ways to do this:
 
 ## Developing
 
+After cloning the repository, make sure you run the following command to pull the `snap-http` submodule:
+
+```shell
+git submodule update --init
+```
+
 To run the full test suite, run the following command:
 
 ```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -86,7 +86,8 @@ parts:
 
        -- Guy Incognito <guy.incognito@landscape.client>  Fri, 1 Sep 2023 00:00:00 +0000
       EOF
-      git archive --prefix landscape-client-0.0.1/ HEAD | tar -x
+      mkdir -p landscape-client-0.0.1
+      git ls-files --recurse-submodules | xargs -I {} cp -r --parents {} landscape-client-0.0.1/
       rm -rf landscape-client-0.0.1/debian
       tar -czf landscape-client-0.0.1.tar.gz landscape-client-0.0.1
       cp -r debian landscape-client-0.0.1


### PR DESCRIPTION
When trying to run `make snap-debug`, the following error occurs:

> :: copying landscape/client/package/taskhandler.py -> /root/parts/landscape-client/build/landscape-client-0.0.1/.pybuild/cpython3_3.10/build/landscape/client/package
> **_:: error: package directory 'landscape/client/snap_http' does not exist_**
> :: E: pybuild pybuild:369: build: plugin distutils failed with: exit code=1: /usr/bin/python3 setup.py build
> :: dh_auto_build: error: pybuild --build -i python{version} -p 3.10 returned exit code 13

`landscape/client/snap_http` is a symlink to `snap-http/snap_http`. Currently, `snap-http` isn't being copied which means the symlink is not resolved, hence the _"package directory 'landscape/client/snap_http' does not exist"_ error. This change ensures that the `snap-http` submodule is copied as well

---

Make sure you run `git submodule update --init` to pull the `snap-http` submodule.