### PR TITLE
snap: set some fallbacks for values used in the hook

### DIFF
--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -12,6 +12,14 @@ if [ -z "$_url" ]; then
   _url="https://landscape.canonical.com"
 fi
 
+if [ -z "$_account" ]; then
+  _account="standalone"
+fi
+
+if [ -z "$_title" ]; then
+  _title=$(hostname)
+fi
+
 cat > "$CLIENT_CONF" << EOF
 [client]
 account_name = $_account


### PR DESCRIPTION
Set account to standalone if not set by the gadget and set computer-title to the output of hostname if not set by the gadget