### PR TITLE
add: computer title generation for zero-touch deployment

### DIFF
--- a/landscape/client/monitor/computerinfo.py
+++ b/landscape/client/monitor/computerinfo.py
@@ -5,7 +5,7 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.internet.defer import returnValue
 
 from landscape.client.monitor.plugin import MonitorPlugin
-from landscape.client.snap_utils import get_assertions
+from landscape.client.snap_utils import get_snap_info
 from landscape.lib.cloud import fetch_ec2_meta_data
 from landscape.lib.fetch import fetch_async
 from landscape.lib.fs import read_text_file
@@ -221,10 +221,9 @@ class ComputerInfo(MonitorPlugin):
     def _create_snap_info_message(self):
         """Create message with the snapd serial metadata."""
         message = {}
-        assertions = get_assertions("serial")
-        if assertions:
-            assertion = assertions[0]
-            self._add_if_new(message, "brand", assertion["brand-id"])
-            self._add_if_new(message, "model", assertion["model"])
-            self._add_if_new(message, "serial", assertion["serial"])
+        snap_info = get_snap_info()
+        if snap_info:
+            self._add_if_new(message, "brand", snap_info["brand"])
+            self._add_if_new(message, "model", snap_info["model"])
+            self._add_if_new(message, "serial", snap_info["serial"])
         return message

--- a/landscape/client/monitor/tests/test_computerinfo.py
+++ b/landscape/client/monitor/tests/test_computerinfo.py
@@ -560,7 +560,7 @@ DISTRIB_NEW_UNEXPECTED_KEY=ooga
             result,
         )
 
-    @mock.patch("landscape.client.monitor.computerinfo.get_assertions")
+    @mock.patch("landscape.client.snap_utils.get_assertions")
     def test_snap_info(self, mock_get_assertions):
         """Test getting the snap info message."""
         mock_get_assertions.return_value = [
@@ -586,7 +586,7 @@ DISTRIB_NEW_UNEXPECTED_KEY=ooga
             "03961d5d-26e5-443f-838d-6db046126bea",
         )
 
-    @mock.patch("landscape.client.monitor.computerinfo.get_assertions")
+    @mock.patch("landscape.client.snap_utils.get_assertions")
     def test_snap_info_no_results(self, mock_get_assertions):
         """Test getting the snap info message when there are no results.
 

--- a/landscape/client/snap_utils.py
+++ b/landscape/client/snap_utils.py
@@ -36,3 +36,16 @@ def get_assertions(assertion_type: str):
             assertions.append(assertion)
 
     return assertions
+
+
+def get_snap_info():
+    """Get the snap device information."""
+    info = {}
+
+    serial_as = get_assertions("serial")
+    if serial_as:
+        info["serial"] = serial_as[0]["serial"]
+        info["model"] = serial_as[0]["model"]
+        info["brand"] = serial_as[0]["brand-id"]
+
+    return info

--- a/landscape/client/tests/test_watchdog.py
+++ b/landscape/client/tests/test_watchdog.py
@@ -1509,3 +1509,23 @@ class WatchDogRunTests(LandscapeTest):
         self.assertNotIn("LANDSCAPE_ATTACHMENTS", os.environ)
         self.assertNotIn("MAIL", os.environ)
         self.assertEqual(os.environ["UNRELATED"], "unrelated")
+
+    @mock.patch.object(WatchDogConfiguration, "auto_configure")
+    @mock.patch("landscape.client.watchdog.IS_SNAP", "1")
+    def test_is_snap(self, mock_auto_configure):
+        """Should call `WatchDogConfiguration.auto_configure`."""
+        reactor = FakeReactor()
+        self.fake_pwd.addUser(
+            "landscape",
+            None,
+            os.getuid(),
+            None,
+            None,
+            None,
+            None,
+        )
+        with mock.patch("landscape.client.watchdog.pwd", new=self.fake_pwd):
+            run(["--log-dir", self.makeDir()], reactor=reactor)
+
+        mock_auto_configure.assert_called_once_with()
+        self.assertTrue(reactor.running)

--- a/landscape/client/watchdog.py
+++ b/landscape/client/watchdog.py
@@ -25,6 +25,7 @@ from twisted.internet.defer import succeed
 from twisted.internet.error import ProcessExitedAlready
 from twisted.internet.protocol import ProcessProtocol
 
+from landscape.client import IS_SNAP
 from landscape.client import USER
 from landscape.client.broker.amp import RemoteBrokerConnector
 from landscape.client.broker.amp import RemoteManagerConnector
@@ -718,6 +719,9 @@ def run(args=sys.argv, reactor=None):
         sys.exit(f"landscape-client can only be run as 'root' or '{USER}'.")
 
     init_logging(config, "watchdog")
+
+    if IS_SNAP:
+        config.auto_configure()
 
     application = Application("landscape-client")
     watchdog_service = WatchDogService(config)

--- a/landscape/lib/format.py
+++ b/landscape/lib/format.py
@@ -1,4 +1,5 @@
 import inspect
+import subprocess
 
 
 def format_object(object):
@@ -29,3 +30,24 @@ def format_percent(percent):
     if not percent:
         percent = 0.0
     return f"{float(percent):.02f}%"
+
+
+def expandvars(pattern: str, **kwargs) -> str:
+    """Expand the pattern by replacing the params with values in `kwargs`.
+
+    This uses bash shell parameter expansion. Here are some examples of
+    possible patterns:
+        - ${parameter}
+        - ${parameter:offset} - start at `offset` to the end
+        - ${parameter:offset:length} - start at `offset` to `offset + length`
+    """
+    values = {k: str(v) for k, v in kwargs.items()}
+    shell = subprocess.run(
+        f'echo -n "{pattern.lower()}"',
+        text=True,
+        capture_output=True,
+        shell=True,
+        executable="/usr/bin/bash",
+        env=values,
+    )
+    return shell.stdout

--- a/landscape/lib/tests/test_format.py
+++ b/landscape/lib/tests/test_format.py
@@ -1,5 +1,6 @@
 import unittest
 
+from landscape.lib.format import expandvars
 from landscape.lib.format import format_delta
 from landscape.lib.format import format_object
 from landscape.lib.format import format_percent
@@ -63,3 +64,91 @@ class FormatPercentTest(unittest.TestCase):
 
     def test_format_none(self):
         self.assertEqual(format_percent(None), "0.00%")
+
+
+class ExpandVarsTest(unittest.TestCase):
+    def test_expand_without_offset_and_length(self):
+        self.assertEqual(
+            expandvars("${serial}", serial="f315cab5"),
+            "f315cab5",
+        )
+        self.assertEqual(
+            expandvars("before:${Serial}", serial="f315cab5"),
+            "before:f315cab5",
+        )
+        self.assertEqual(
+            expandvars("${serial}:after", serial="f315cab5"),
+            "f315cab5:after",
+        )
+        self.assertEqual(
+            expandvars("be\\$fore:${serial}:after", serial="f315cab5"),
+            "be$fore:f315cab5:after",
+        )
+
+    def test_expand_with_offset(self):
+        self.assertEqual(
+            expandvars("${serial:7}", serial="01234567890abcdefgh"),
+            "7890abcdefgh",
+        )
+        self.assertEqual(
+            expandvars("before:${SERIAL:7}", serial="01234567890abcdefgh"),
+            "before:7890abcdefgh",
+        )
+        self.assertEqual(
+            expandvars("${serial:7}:after", serial="01234567890abcdefgh"),
+            "7890abcdefgh:after",
+        )
+        self.assertEqual(
+            expandvars(
+                "be\\$fore:${serial:7}:after",
+                serial="01234567890abcdefgh",
+            ),
+            "be$fore:7890abcdefgh:after",
+        )
+
+    def test_expand_with_offset_and_length(self):
+        self.assertEqual(
+            expandvars("${serial:7:0}", serial="01234567890abcdefgh"),
+            "",
+        )
+        self.assertEqual(
+            expandvars("before:${serial:7:2}", serial="01234567890abcdefgh"),
+            "before:78",
+        )
+        self.assertEqual(
+            expandvars("${serial:7:2}:after", serial="01234567890abcdefgh"),
+            "78:after",
+        )
+        self.assertEqual(
+            expandvars(
+                "be\\$fore:${serial:7:2}:after",
+                serial="01234567890abcdefgh",
+            ),
+            "be$fore:78:after",
+        )
+
+    def test_expand_multiple(self):
+        self.assertEqual(
+            expandvars(
+                "${model:8:7}-${serial:0:8}",
+                model="generic-classic",
+                serial="f315cab5-ba74-4d3c-be85-713406455773",
+            ),
+            "classic-f315cab5",
+        )
+
+    def test_expand_offset_longer_than_substitute(self):
+        self.assertEqual(
+            expandvars("${serial:50}", serial="01234567890abcdefgh"),
+            "",
+        )
+
+    def test_expand_length_longer_than_substitute(self):
+        self.assertEqual(
+            expandvars("${serial:1:100}", serial="01234567890abcdefgh"),
+            "1234567890abcdefgh",
+        )
+
+    def test_expand_with_non_string_substitutes(self):
+        self.assertEqual(expandvars("${foo}", foo=42), "42")
+        self.assertEqual(expandvars("${foo}.bar", foo=42), "42.bar")

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+if [ "$( snapctl model | awk '/^classic:/ { print $2 }' )" != "true" ]
+then snapctl start --enable "$SNAP_INSTANCE_NAME.landscape-client"
+fi


### PR DESCRIPTION
If auto-registration is enabled & the auto-registration process has not already run, the client will attempt to generate a computer title based on `computer-title-pattern` (see the L017 spec.). If other configuration is ok (API URLs, account name, etc), the client will contact the landscape server and automatically request registration within ~5 minutes. 

Sample registration request with `computer-title-pattern="${model:8:7}-${serial:0:8}"`:

![image](https://github.com/canonical/landscape-client/assets/43380836/0d274b68-897b-4135-b408-565e276a0075)
