### PR TITLE
Remote script execution for snaps

### DIFF
--- a/landscape/client/manager/scriptexecution.py
+++ b/landscape/client/manager/scriptexecution.py
@@ -175,9 +175,8 @@ class ScriptExecutionPlugin(ManagerPlugin, ScriptRunnerMixin):
     def _handle_execute_script(self, message):
         opid = message["operation-id"]
         try:
-            user = message["username"]
-            if IS_SNAP:
-                user = "root"
+            user = message["username"] if not IS_SNAP else "root"
+
             if not self.is_user_allowed(user):
                 return self._respond(
                     FAILED,

--- a/landscape/client/manager/tests/test_scriptexecution.py
+++ b/landscape/client/manager/tests/test_scriptexecution.py
@@ -42,11 +42,13 @@ def get_default_environment():
         "USER": username,
         "HOME": home,
     }
-    for var in {"LANG", 
-                "LC_ALL", 
-                "LC_CTYPE",
-                "LD_LIBRARY_PATH",
-                "PYTHONPATH",}:
+    for var in {
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "LD_LIBRARY_PATH",
+        "PYTHONPATH",
+    }:
         if var in os.environ:
             env[var] = os.environ[var]
     return env

--- a/landscape/client/manager/tests/test_scriptexecution.py
+++ b/landscape/client/manager/tests/test_scriptexecution.py
@@ -42,7 +42,11 @@ def get_default_environment():
         "USER": username,
         "HOME": home,
     }
-    for var in {"LANG", "LC_ALL", "LC_CTYPE"}:
+    for var in {"LANG", 
+                "LC_ALL", 
+                "LC_CTYPE",
+                "LD_LIBRARY_PATH",
+                "PYTHONPATH",}:
         if var in os.environ:
             env[var] = os.environ[var]
     return env

--- a/landscape/client/manager/tests/test_scriptexecution.py
+++ b/landscape/client/manager/tests/test_scriptexecution.py
@@ -456,18 +456,15 @@ class RunScriptTests(LandscapeTest):
         protocol.processEnded(Failure(ProcessDone(0)))
 
         def check(result):
-            if from_snap:
-                mock.chown.assert_not_called()
-            else:
-                mock_chown.assert_called_with()
-                self.assertEqual(result, "foobar")
+            mock_chown.assert_called()
+            self.assertEqual(result, "foobar")
 
         def cleanup(result):
             patch_chown.stop()
             patch_issnap.stop()
             return result
 
-        return result.addErrback(check).addBoth(cleanup)
+        return result.addCallback(check).addBoth(cleanup)
 
     def test_user(self):
         """
@@ -496,11 +493,6 @@ class RunScriptTests(LandscapeTest):
         username = info.pw_name
         gid = info.pw_gid
         path = info.pw_dir
-
-        if gid == 0:
-            gid = 1234
-        if uid == 0:
-            uid = 5678
 
         return self._run_script(username, uid, gid, path, from_snap=True)
 

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -20,7 +20,7 @@ url = ${_url}/message-system
 ping_url = ${_url}/ping
 log_level = info
 script_users = ALL
-manager_plugins = ProcessKiller,UserManager,ShutdownManager,HardwareInfo,KeystoneToken,SnapManager
+manager_plugins = ProcessKiller,UserManager,ShutdownManager,HardwareInfo,KeystoneToken,SnapManager,ScriptExecution
 monitor_plugins = ActiveProcessInfo,ComputerInfo,LoadAverage,MemoryInfo,MountInfo,ProcessorInfo,Temperature,UserMonitor,RebootRequired,NetworkActivity,NetworkDevice,CPUUsage,SwiftUsage,CephUsage,ComputerTags,SnapMonitor
 EOF
 


### PR DESCRIPTION
* Enable remote script execution in the snap.
* When a snap execute all scripts as root (confined by the snap)
* Add LD_LIBRARY and PYTHONPATH env variables to script execution environment.