### PR TITLE
add: user management on Core

### DIFF
--- a/landscape/client/monitor/usermonitor.py
+++ b/landscape/client/monitor/usermonitor.py
@@ -3,6 +3,7 @@ import os.path
 
 from twisted.internet.defer import maybeDeferred
 
+from landscape.client import IS_CORE
 from landscape.client.amp import ComponentConnector
 from landscape.client.amp import ComponentPublisher
 from landscape.client.amp import remote
@@ -27,8 +28,14 @@ class UserMonitor(MonitorPlugin):
     name = "usermonitor"
 
     def __init__(self, provider=None):
-        if provider is None:
-            provider = UserProvider()
+        if IS_CORE:
+            provider = provider or UserProvider(
+                passwd_file="/var/lib/extrausers/passwd",
+                group_file="/var/lib/extrausers/group",
+            )
+        else:
+            provider = provider or UserProvider()
+
         self._provider = provider
         self._publisher = None
 


### PR DESCRIPTION
This change allows us to list, add, and remove SSO users on Ubuntu Core systems.

Example listing on staging:
![Screenshot from 2024-02-05 12-51-12](https://github.com/canonical/landscape-client/assets/43380836/cf8a6bad-c098-467d-be0e-30064c661a75)

Depends on https://github.com/Perfect5th/snap-http/pull/7