### PR TITLE
fix running tasks on the snap manager

### DIFF
--- a/landscape/client/manager/snapmanager.py
+++ b/landscape/client/manager/snapmanager.py
@@ -86,7 +86,7 @@ class SnapManager(ManagerPlugin):
                 snaps,
                 **snap_args,
             )
-            queue.append((response["change"], "BATCH"))
+            queue.append((response.change, "BATCH"))
         except SnapdHttpException as e:
             result = json.loads(e.args[0])["result"]
             logging.error(
@@ -130,7 +130,7 @@ class SnapManager(ManagerPlugin):
                     name,
                     **snap_args,
                 )
-                queue.append((response["change"], name))
+                queue.append((response.change, name))
             except SnapdHttpException as e:
                 result = json.loads(e.args[0])["result"]
                 logging.error(
@@ -163,7 +163,7 @@ class SnapManager(ManagerPlugin):
             logging.info("Polling snapd for status of pending snap changes")
 
             try:
-                result = snap_http.check_changes().get("result", [])
+                result = snap_http.check_changes().result
                 result_dict = {c["id"]: c for c in result}
             except SnapdHttpException as e:
                 logging.error(f"Error checking status of snap changes: {e}")
@@ -208,7 +208,7 @@ class SnapManager(ManagerPlugin):
 
         response = snap_method(*args, **kwargs)
 
-        if "change" not in response:
+        if response.change is None:
             raise SnapdHttpException(response)
 
         return response

--- a/landscape/client/manager/tests/test_snapmanager.py
+++ b/landscape/client/manager/tests/test_snapmanager.py
@@ -39,20 +39,23 @@ class SnapManagerTest(LandscapeTest):
 
         def install_snap(name, revision=None, channel=None, classic=False):
             if name == "hello":
-                return {"change": "1"}
+                return SnapdResponse("async", 200, "OK", None, change="1")
 
             if name == "goodbye":
-                return {"change": "2"}
+                return SnapdResponse("async", 200, "OK", None, change="2")
 
             return mock.DEFAULT
 
         self.snap_http.install.side_effect = install_snap
-        self.snap_http.check_changes.return_value = {
-            "result": [
+        self.snap_http.check_changes.return_value = SnapdResponse(
+            "sync",
+            "200",
+            "OK",
+            [
                 {"id": "1", "status": "Done"},
                 {"id": "2", "status": "Done"},
             ],
-        }
+        )
         self.snap_http.list.return_value = SnapdResponse(
             "sync",
             200,
@@ -92,10 +95,19 @@ class SnapManagerTest(LandscapeTest):
         When no channels or revisions are specified, snaps are installed
         via a single call to snapd.
         """
-        self.snap_http.install_all.return_value = {"change": "1"}
-        self.snap_http.check_changes.return_value = {
-            "result": [{"id": "1", "status": "Done"}],
-        }
+        self.snap_http.install_all.return_value = SnapdResponse(
+            "async",
+            202,
+            "Accepted",
+            None,
+            change="1",
+        )
+        self.snap_http.check_changes.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [{"id": "1", "status": "Done"}],
+        )
         self.snap_http.list.return_value = SnapdResponse(
             "sync",
             200,
@@ -180,10 +192,24 @@ class SnapManagerTest(LandscapeTest):
         return result.addCallback(got_result)
 
     def test_install_snap_no_status(self):
-        self.snap_http.install_all.return_value = {"change": "1"}
-        self.snap_http.check_changes.return_value = {"result": []}
+        self.snap_http.install_all.return_value = SnapdResponse(
+            "async",
+            202,
+            "Accepted",
+            None,
+            change="1",
+        )
+        self.snap_http.check_changes.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [],
+        )
         self.snap_http.list.return_value = SnapdResponse(
-            "sync", 200, "OK", {"installed": []}
+            "sync",
+            200,
+            "OK",
+            {"installed": []},
         )
 
         result = self.manager.dispatch_message(
@@ -211,10 +237,19 @@ class SnapManagerTest(LandscapeTest):
         return result.addCallback(got_result)
 
     def test_install_snap_check_error(self):
-        self.snap_http.install_all.return_value = {"change": "1"}
+        self.snap_http.install_all.return_value = SnapdResponse(
+            "async",
+            200,
+            "Accepted",
+            None,
+            change="1",
+        )
         self.snap_http.check_changes.side_effect = SnapdHttpException("whoops")
         self.snap_http.list.return_value = SnapdResponse(
-            "sync", 200, "OK", {"installed": []}
+            "sync",
+            200,
+            "OK",
+            {"installed": []},
         )
 
         result = self.manager.dispatch_message(
@@ -244,12 +279,24 @@ class SnapManagerTest(LandscapeTest):
         return result.addCallback(got_result)
 
     def test_remove_snap(self):
-        self.snap_http.remove_all.return_value = {"change": "1"}
-        self.snap_http.check_changes.return_value = {
-            "result": [{"id": "1", "status": "Done"}],
-        }
+        self.snap_http.remove_all.return_value = SnapdResponse(
+            "async",
+            202,
+            "Accepted",
+            None,
+            change="1",
+        )
+        self.snap_http.check_changes.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [{"id": "1", "status": "Done"}],
+        )
         self.snap_http.list.return_value = SnapdResponse(
-            "sync", 200, "OK", {"installed": []}
+            "sync",
+            200,
+            "OK",
+            {"installed": []},
         )
 
         result = self.manager.dispatch_message(
@@ -277,12 +324,24 @@ class SnapManagerTest(LandscapeTest):
         return result.addCallback(got_result)
 
     def test_set_config(self):
-        self.snap_http.set_conf.return_value = {"change": "1"}
-        self.snap_http.check_changes.return_value = {
-            "result": [{"id": "1", "status": "Done"}],
-        }
+        self.snap_http.set_conf.return_value = SnapdResponse(
+            "async",
+            202,
+            "Accepted",
+            None,
+            change="1",
+        )
+        self.snap_http.check_changes.return_value = SnapdResponse(
+            "sync",
+            "200",
+            "OK",
+            [{"id": "1", "status": "Done"}],
+        )
         self.snap_http.list.return_value = SnapdResponse(
-            "sync", 200, "OK", {"installed": []}
+            "sync",
+            200,
+            "OK",
+            {"installed": []},
         )
 
         result = self.manager.dispatch_message(
@@ -293,9 +352,9 @@ class SnapManagerTest(LandscapeTest):
                     {
                         "name": "hello",
                         "config": {"foo": {"bar": "qux", "baz": "quux"}},
-                    }
+                    },
                 ],
-            }
+            },
         )
 
         def got_result(r):
@@ -318,11 +377,17 @@ class SnapManagerTest(LandscapeTest):
         self.snap_http.set_conf.side_effect = SnapdHttpException(
             b'{"result": "whoops"}',
         )
-        self.snap_http.check_changes.return_value = {
-            "result": [{"id": "1", "status": "Done"}],
-        }
+        self.snap_http.check_changes.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [{"id": "1", "status": "Done"}],
+        )
         self.snap_http.list.return_value = SnapdResponse(
-            "sync", 200, "OK", {"installed": []}
+            "sync",
+            200,
+            "OK",
+            {"installed": []},
         )
 
         result = self.manager.dispatch_message(
@@ -333,9 +398,9 @@ class SnapManagerTest(LandscapeTest):
                     {
                         "name": "hello",
                         "config": {"foo": {"bar": "qux", "baz": "quux"}},
-                    }
+                    },
                 ],
-            }
+            },
         )
 
         def got_result(r):

--- a/landscape/client/monitor/snapmonitor.py
+++ b/landscape/client/monitor/snapmonitor.py
@@ -30,7 +30,7 @@ class SnapMonitor(DataWatcher):
 
         for i in range(len(snaps)):
             try:
-                config = snap_http.get_conf(snaps[i]["name"])
+                config = snap_http.get_conf(snaps[i]["name"]).result
             except SnapdHttpException:
                 config = {}
 

--- a/landscape/client/monitor/tests/test_snapmonitor.py
+++ b/landscape/client/monitor/tests/test_snapmonitor.py
@@ -66,13 +66,18 @@ class SnapMonitorTest(LandscapeTest):
                     "confinement": "strict",
                     "version": "v1.0",
                     "id": "123",
-                }
+                },
             ],
         )
-        snap_http_mock.get_conf.return_value = {
-            "foo": {"baz": "default", "qux": [1, True, 2.0]},
-            "bar": "enabled",
-        }
+        snap_http_mock.get_conf.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            {
+                "foo": {"baz": "default", "qux": [1, True, 2.0]},
+                "bar": "enabled",
+            },
+        )
         plugin.exchange()
 
         messages = self.mstore.get_pending_messages()


### PR DESCRIPTION
These changes were missed during the migration to the `snap-http` library.