### PR TITLE
bpickle: guard against negative string/bytestring lengths

### DIFF
--- a/landscape/lib/bpickle.py
+++ b/landscape/lib/bpickle.py
@@ -125,13 +125,23 @@ def loads_float(bytestring, pos, as_is=False):
 
 def loads_bytes(bytestring, pos, as_is=False):
     startpos = bytestring.index(b":", pos) + 1
-    endpos = startpos + int(bytestring[pos + 1 : startpos - 1])
+    step = int(bytestring[pos + 1 : startpos - 1])
+
+    if step < 0:
+        raise ValueError(f"Negative bytestring length: {step}")
+
+    endpos = startpos + step
     return bytestring[startpos:endpos], endpos
 
 
 def loads_unicode(bytestring, pos, as_is=False):
     startpos = bytestring.index(b":", pos) + 1
-    endpos = startpos + int(bytestring[pos + 1 : startpos - 1])
+    step = int(bytestring[pos + 1 : startpos - 1])
+
+    if step < 0:
+        raise ValueError(f"Negative unicode length: {step}")
+
+    endpos = startpos + step
     return bytestring[startpos:endpos].decode("utf-8"), endpos
 
 

--- a/landscape/lib/tests/test_bpickle.py
+++ b/landscape/lib/tests/test_bpickle.py
@@ -18,8 +18,14 @@ class BPickleTest(unittest.TestCase):
     def test_bytes(self):
         self.assertEqual(bpickle.loads(bpickle.dumps(b"foo")), b"foo")
 
+    def test_bytes_negative_length(self):
+        self.assertRaises(ValueError, bpickle.loads, b"ds-4:tests5:thing;")
+
     def test_string(self):
         self.assertEqual(bpickle.loads(bpickle.dumps("foo")), "foo")
+
+    def test_string_negative_length(self):
+        self.assertRaises(ValueError, bpickle.loads, b"du-4:testu5:thing;")
 
     def test_list(self):
         self.assertEqual(


### PR DESCRIPTION
bpickle has a bug: if you ask it to `loads` a dict, list, or tuple containing a string or bytestring with a negative length, it can enter an infinite loop as it steps back and scans the same section of the string repeatedly.

Fairly minimal reproduction:
```python
from landscape.lib import bpickle

bpickle.loads(b'lu-4test;')
```
This appears to never return.

Fix is to guard against negative length values. Zero values are okay, as you already get a different error for those, though it could perhaps be clearer.