### PR TITLE
add: snap services management

### DIFF
--- a/landscape/client/manager/snapmanager.py
+++ b/landscape/client/manager/snapmanager.py
@@ -36,6 +36,12 @@ class SnapManager(ManagerPlugin):
             "unhold-snaps": snap_http.unhold,
             "unhold-snaps-batch": snap_http.unhold_all,
             "set-snap-config": snap_http.set_conf,
+            "start-snap-service": snap_http.start,
+            "start-snap-service-batch": snap_http.start_all,
+            "stop-snap-service": snap_http.stop,
+            "stop-snap-service-batch": snap_http.stop_all,
+            "restart-snap-service": snap_http.restart,
+            "restart-snap-service-batch": snap_http.restart_all,
         }
 
     def register(self, registry):
@@ -48,6 +54,24 @@ class SnapManager(ManagerPlugin):
         registry.register_message("hold-snaps", self._handle_snap_task)
         registry.register_message("unhold-snaps", self._handle_snap_task)
         registry.register_message("set-snap-config", self._handle_snap_task)
+        registry.register_message("start-snap-service", self._handle_snap_task)
+        registry.register_message(
+            "start-snap-service-batch",
+            self._handle_snap_task,
+        )
+        registry.register_message("stop-snap-service", self._handle_snap_task)
+        registry.register_message(
+            "stop-snap-service-batch",
+            self._handle_snap_task,
+        )
+        registry.register_message(
+            "restart-snap-service",
+            self._handle_snap_task,
+        )
+        registry.register_message(
+            "restart-snap-service-batch",
+            self._handle_snap_task,
+        )
 
     def _handle_snap_task(self, message):
         """

--- a/landscape/client/monitor/tests/test_snapmonitor.py
+++ b/landscape/client/monitor/tests/test_snapmonitor.py
@@ -78,6 +78,12 @@ class SnapMonitorTest(LandscapeTest):
                 "bar": "enabled",
             },
         )
+        snap_http_mock.get_apps.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [],
+        )
         plugin.exchange()
 
         messages = self.mstore.get_pending_messages()
@@ -97,3 +103,86 @@ class SnapMonitorTest(LandscapeTest):
                 ),
             },
         )
+
+    @patch("landscape.client.monitor.snapmonitor.snap_http")
+    def test_get_snap_services(self, snap_http_mock):
+        """Tests that we can get and coerce snap services."""
+        plugin = SnapMonitor()
+        self.monitor.add(plugin)
+
+        services = [
+            {
+                "snap": "test-snap",
+                "name": "hello-svc",
+                "daemon": "simple",
+                "daemon-scope": "system",
+                "active": True,
+            },
+            {
+                "snap": "test-snap",
+                "name": "bye-svc",
+                "daemon": "simple",
+                "daemon-scope": "system",
+            },
+            {
+                "activators": [
+                    {
+                        "Active": True,
+                        "Enabled": True,
+                        "Name": "unix",
+                        "Type": "socket",
+                    },
+                ],
+                "daemon": "simple",
+                "daemon-scope": "system",
+                "enabled": True,
+                "name": "user-daemon",
+                "snap": "lxd",
+            },
+        ]
+        snap_http_mock.list.return_value = SnapdResponse("sync", 200, "OK", [])
+        snap_http_mock.get_conf.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            {},
+        )
+        snap_http_mock.get_apps.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            services,
+        )
+        plugin.exchange()
+
+        messages = self.mstore.get_pending_messages()
+
+        self.assertTrue(len(messages) > 0)
+        self.assertCountEqual(messages[0]["snaps"]["services"], services)
+
+    @patch("landscape.client.monitor.snapmonitor.snap_http")
+    def test_get_snap_services_error(self, snap_http_mock):
+        """Tests that we can get and coerce snap services."""
+        plugin = SnapMonitor()
+        self.monitor.add(plugin)
+
+        snap_http_mock.list.return_value = SnapdResponse("sync", 200, "OK", [])
+        snap_http_mock.get_conf.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            {},
+        )
+
+        with self.assertLogs(level="WARNING") as cm:
+            snap_http_mock.get_apps.side_effect = SnapdHttpException
+            plugin.exchange()
+
+        messages = self.mstore.get_pending_messages()
+
+        self.assertTrue(len(messages) > 0)
+        self.assertEqual(
+            cm.output,
+            ["WARNING:root:Unable to list services: "],
+        )
+        self.assertCountEqual(messages[0]["snaps"]["services"], [])

--- a/landscape/message_schemas/server_bound.py
+++ b/landscape/message_schemas/server_bound.py
@@ -803,7 +803,34 @@ SNAPS = Message(
                         ],
                     ),
                 ),
+                "services": List(
+                    KeyDict(
+                        {
+                            "name": Unicode(),
+                            "snap": Unicode(),
+                            "desktop-file": Unicode(),
+                            "daemon": Unicode(),
+                            "daemon-scope": Unicode(),
+                            "enabled": Bool(),
+                            "active": Bool(),
+                            "activators": List(
+                                Dict(Unicode(), Any(Unicode(), Bool())),
+                            ),
+                        },
+                        strict=False,
+                        optional=[
+                            "snap",
+                            "desktop-file",
+                            "daemon",
+                            "daemon-scope",
+                            "enabled",
+                            "active",
+                            "activators",
+                        ],
+                    ),
+                ),
             },
+            optional=["services"],
         ),
     },
 )


### PR DESCRIPTION
In addition to the running processes, we should send the running snap services to the Landscape server. This will then permit the display of these services along with the option to trigger start/stop/restart commands.