### PR TITLE
refactor: move snap services to separate manager & monitor

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -96,6 +96,8 @@ ignore_sigusr1 = False
 #   UbuntuProInfo - Ubuntu Pro registration information
 #   LivePatch - Livepath status information
 #   UbuntuProRebootRequired - informs if the system needs to be rebooted
+#   SnapMonitor - manage installed snaps
+#   SnapServicesMonitor - manage snap services
 #
 # The special value "ALL" is an alias for the full list of plugins.
 monitor_plugins = ALL
@@ -178,6 +180,7 @@ cloud = True
 #   HardwareInfo
 #   KeystoneToken
 #   SnapManager
+#   SnapServicesManager
 #
 # The special value "ALL" is an alias for the entire list of plugins above and is the default.
 manager_plugins = ALL

--- a/landscape/client/manager/config.py
+++ b/landscape/client/manager/config.py
@@ -13,6 +13,7 @@ ALL_PLUGINS = [
     "HardwareInfo",
     "KeystoneToken",
     "SnapManager",
+    "SnapServicesManager",
     "UbuntuProInfo",
 ]
 

--- a/landscape/client/manager/snapservicesmanager.py
+++ b/landscape/client/manager/snapservicesmanager.py
@@ -1,0 +1,60 @@
+import logging
+
+from landscape.client import snap_http
+from landscape.client.manager.snapmanager import BaseSnapManager
+from landscape.client.snap_http import SnapdHttpException
+
+
+class SnapServicesManager(BaseSnapManager):
+    """
+    Plugin that updates the state of snap services on this machine, starting,
+    stopping, restarting, enabling, disabling, and reloading them in response
+    to messages.
+
+    Changes trigger SnapServicesMonitor to send an updated state message
+    immediately.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self.SNAP_METHODS = {
+            "start-snap-service": snap_http.start,
+            "start-snap-service-batch": snap_http.start_all,
+            "stop-snap-service": snap_http.stop,
+            "stop-snap-service-batch": snap_http.stop_all,
+            "restart-snap-service": snap_http.restart,
+            "restart-snap-service-batch": snap_http.restart_all,
+        }
+
+    def register(self, registry):
+        super().register(registry)
+        self.config = registry.config
+
+        message_types = [
+            "start-snap-service",
+            "start-snap-service-batch",
+            "stop-snap-service",
+            "stop-snap-service-batch",
+            "restart-snap-service",
+            "restart-snap-service-batch",
+        ]
+        for msg_type in message_types:
+            registry.register_message(msg_type, self._handle_snap_task)
+
+    def _send_snap_update(self):
+        try:
+            services = snap_http.get_apps(services_only=True).result
+        except SnapdHttpException as e:
+            logging.error(f"Unable to list services: {e}")
+            return
+
+        if services:
+            return self.registry.broker.send_message(
+                {
+                    "type": "snap-services",
+                    "services": {"running": services},
+                },
+                self._session_id,
+                True,
+            )

--- a/landscape/client/manager/tests/test_config.py
+++ b/landscape/client/manager/tests/test_config.py
@@ -21,6 +21,7 @@ class ManagerConfigurationTest(LandscapeTest):
                 "HardwareInfo",
                 "KeystoneToken",
                 "SnapManager",
+                "SnapServicesManager",
                 "UbuntuProInfo",
             ],
             ALL_PLUGINS,

--- a/landscape/client/manager/tests/test_snapmanager.py
+++ b/landscape/client/manager/tests/test_snapmanager.py
@@ -56,12 +56,7 @@ class SnapManagerTest(LandscapeTest):
                 {"id": "2", "status": "Done"},
             ],
         )
-        self.snap_http.list.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            {"installed": []},
-        )
+        self.snap_http.list.return_value = SnapdResponse("sync", 200, "OK", [])
 
         result = self.manager.dispatch_message(
             {
@@ -74,7 +69,7 @@ class SnapManagerTest(LandscapeTest):
             },
         )
 
-        def got_result(r):
+        def got_result(_):
             self.assertMessages(
                 self.broker_service.message_store.get_pending_messages(),
                 [
@@ -112,19 +107,17 @@ class SnapManagerTest(LandscapeTest):
             "sync",
             200,
             "OK",
-            {
-                "installed": [
-                    {
-                        "name": "hello",
-                        "id": "test",
-                        "confinement": "strict",
-                        "tracking-channel": "latest/stable",
-                        "revision": "100",
-                        "publisher": {"validation": "yep", "username": "me"},
-                        "version": "1.2.3",
-                    },
-                ],
-            },
+            [
+                {
+                    "name": "hello",
+                    "id": "test",
+                    "confinement": "strict",
+                    "tracking-channel": "latest/stable",
+                    "revision": "100",
+                    "publisher": {"validation": "yep", "username": "me"},
+                    "version": "1.2.3",
+                },
+            ],
         )
 
         result = self.manager.dispatch_message(
@@ -138,7 +131,7 @@ class SnapManagerTest(LandscapeTest):
             },
         )
 
-        def got_result(r):
+        def got_result(_):
             self.assertMessages(
                 self.broker_service.message_store.get_pending_messages(),
                 [
@@ -158,12 +151,7 @@ class SnapManagerTest(LandscapeTest):
         self.snap_http.install_all.side_effect = SnapdHttpException(
             b'{"result": "whoops"}',
         )
-        self.snap_http.list.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            {"installed": []},
-        )
+        self.snap_http.list.return_value = SnapdResponse("sync", 200, "OK", [])
 
         result = self.manager.dispatch_message(
             {
@@ -175,7 +163,7 @@ class SnapManagerTest(LandscapeTest):
 
         self.log_helper.ignore_errors(r".+whoops$")
 
-        def got_result(r):
+        def got_result(_):
             self.assertMessages(
                 self.broker_service.message_store.get_pending_messages(),
                 [
@@ -205,12 +193,7 @@ class SnapManagerTest(LandscapeTest):
             "OK",
             [],
         )
-        self.snap_http.list.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            {"installed": []},
-        )
+        self.snap_http.list.return_value = SnapdResponse("sync", 200, "OK", [])
 
         result = self.manager.dispatch_message(
             {
@@ -220,7 +203,7 @@ class SnapManagerTest(LandscapeTest):
             },
         )
 
-        def got_result(r):
+        def got_result(_):
             self.assertMessages(
                 self.broker_service.message_store.get_pending_messages(),
                 [
@@ -245,12 +228,7 @@ class SnapManagerTest(LandscapeTest):
             change="1",
         )
         self.snap_http.check_changes.side_effect = SnapdHttpException("whoops")
-        self.snap_http.list.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            {"installed": []},
-        )
+        self.snap_http.list.return_value = SnapdResponse("sync", 200, "OK", [])
 
         result = self.manager.dispatch_message(
             {
@@ -262,7 +240,7 @@ class SnapManagerTest(LandscapeTest):
 
         self.log_helper.ignore_errors(r".+whoops$")
 
-        def got_result(r):
+        def got_result(_):
             self.assertMessages(
                 self.broker_service.message_store.get_pending_messages(),
                 [
@@ -292,12 +270,7 @@ class SnapManagerTest(LandscapeTest):
             "OK",
             [{"id": "1", "status": "Done"}],
         )
-        self.snap_http.list.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            {"installed": []},
-        )
+        self.snap_http.list.return_value = SnapdResponse("sync", 200, "OK", [])
 
         result = self.manager.dispatch_message(
             {
@@ -307,7 +280,7 @@ class SnapManagerTest(LandscapeTest):
             },
         )
 
-        def got_result(r):
+        def got_result(_):
             self.assertMessages(
                 self.broker_service.message_store.get_pending_messages(),
                 [
@@ -337,12 +310,7 @@ class SnapManagerTest(LandscapeTest):
             "OK",
             [{"id": "1", "status": "Done"}],
         )
-        self.snap_http.list.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            {"installed": []},
-        )
+        self.snap_http.list.return_value = SnapdResponse("sync", 200, "OK", [])
 
         result = self.manager.dispatch_message(
             {
@@ -359,7 +327,7 @@ class SnapManagerTest(LandscapeTest):
             },
         )
 
-        def got_result(r):
+        def got_result(_):
             self.assertMessages(
                 self.broker_service.message_store.get_pending_messages(),
                 [
@@ -379,12 +347,7 @@ class SnapManagerTest(LandscapeTest):
         self.snap_http.set_conf.side_effect = SnapdHttpException(
             b'{"result": "whoops"}',
         )
-        self.snap_http.list.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            {"installed": []},
-        )
+        self.snap_http.list.return_value = SnapdResponse("sync", 200, "OK", [])
 
         result = self.manager.dispatch_message(
             {
@@ -401,7 +364,7 @@ class SnapManagerTest(LandscapeTest):
             },
         )
 
-        def got_result(r):
+        def got_result(_):
             self.assertMessages(
                 self.broker_service.message_store.get_pending_messages(),
                 [
@@ -416,206 +379,5 @@ class SnapManagerTest(LandscapeTest):
                     },
                 ],
             )
-
-        return result.addCallback(got_result)
-
-    def test_start_service(self):
-        self.snap_http.start.return_value = SnapdResponse(
-            "async",
-            202,
-            "Accepted",
-            None,
-            change="1",
-        )
-        self.snap_http.check_changes.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            [{"id": "1", "status": "Done"}],
-        )
-        self.snap_http.list.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            {"installed": []},
-        )
-
-        result = self.manager.dispatch_message(
-            {
-                "type": "start-snap-service",
-                "operation-id": 123,
-                "snaps": [
-                    {"name": "test-snap.hello-svc", "args": {"enable": True}},
-                ],
-            },
-        )
-
-        def got_result(r):
-            self.assertMessages(
-                self.broker_service.message_store.get_pending_messages(),
-                [
-                    {
-                        "type": "operation-result",
-                        "status": SUCCEEDED,
-                        "result-text": "{'completed': ['test-snap.hello-svc'],"
-                        " 'errored': [], 'errors': {}}",
-                        "operation-id": 123,
-                    },
-                ],
-            )
-
-        self.snap_http.start.assert_called_once_with(
-            "test-snap.hello-svc",
-            enable=True,
-        )
-
-        return result.addCallback(got_result)
-
-    def test_start_service_error(self):
-        self.snap_http.start.side_effect = SnapdHttpException(
-            b'{"result": "snap idonotexist not found"}',
-        )
-        self.snap_http.list.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            {"installed": []},
-        )
-
-        result = self.manager.dispatch_message(
-            {
-                "type": "start-snap-service",
-                "operation-id": 123,
-                "snaps": [{"name": "idonotexist", "args": {"enable": True}}],
-            },
-        )
-
-        self.log_helper.ignore_errors(r".+idonotexist$")
-
-        def got_result(r):
-            self.assertMessages(
-                self.broker_service.message_store.get_pending_messages(),
-                [
-                    {
-                        "type": "operation-result",
-                        "status": FAILED,
-                        "result-text": "{'completed': [], "
-                        "'errored': [], 'errors': {'idonotexist': "
-                        "'snap idonotexist not found'}}",
-                        "operation-id": 123,
-                    },
-                ],
-            )
-
-        self.snap_http.start.assert_called_once_with(
-            "idonotexist",
-            enable=True,
-        )
-
-        return result.addCallback(got_result)
-
-    def test_stop_service_batch(self):
-        self.snap_http.stop_all.return_value = SnapdResponse(
-            "async",
-            202,
-            "Accepted",
-            None,
-            change="1",
-        )
-        self.snap_http.check_changes.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            [{"id": "1", "status": "Done"}],
-        )
-        self.snap_http.list.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            {"installed": []},
-        )
-
-        result = self.manager.dispatch_message(
-            {
-                "type": "stop-snap-service",
-                "operation-id": 123,
-                "snaps": [
-                    {"name": "lxd"},
-                    {"name": "landscape-client"},
-                ],
-                "args": {"disable": False},
-            },
-        )
-
-        def got_result(r):
-            self.assertMessages(
-                self.broker_service.message_store.get_pending_messages(),
-                [
-                    {
-                        "type": "operation-result",
-                        "status": SUCCEEDED,
-                        "result-text": "{'completed': ['BATCH'], "
-                        "'errored': [], 'errors': {}}",
-                        "operation-id": 123,
-                    },
-                ],
-            )
-
-        self.snap_http.stop_all.assert_called_once_with(
-            ["lxd", "landscape-client"],
-            disable=False,
-        )
-
-        return result.addCallback(got_result)
-
-    def test_restart_service(self):
-        self.snap_http.restart_all.return_value = SnapdResponse(
-            "async",
-            202,
-            "Accepted",
-            None,
-            change="1",
-        )
-        self.snap_http.check_changes.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            [{"id": "1", "status": "Done"}],
-        )
-        self.snap_http.list.return_value = SnapdResponse(
-            "sync",
-            200,
-            "OK",
-            {"installed": []},
-        )
-
-        result = self.manager.dispatch_message(
-            {
-                "type": "restart-snap-service",
-                "operation-id": 123,
-                "snaps": [
-                    {"name": "test-snap"},
-                    {"name": "lxd"},
-                ],
-            },
-        )
-
-        def got_result(r):
-            self.assertMessages(
-                self.broker_service.message_store.get_pending_messages(),
-                [
-                    {
-                        "type": "operation-result",
-                        "status": SUCCEEDED,
-                        "result-text": "{'completed': ['BATCH'], "
-                        "'errored': [], 'errors': {}}",
-                        "operation-id": 123,
-                    },
-                ],
-            )
-
-        self.snap_http.restart_all.assert_called_once_with(
-            ["test-snap", "lxd"],
-        )
 
         return result.addCallback(got_result)

--- a/landscape/client/manager/tests/test_snapservicesmanager.py
+++ b/landscape/client/manager/tests/test_snapservicesmanager.py
@@ -1,0 +1,333 @@
+import sys
+from unittest import mock
+
+from landscape.client.manager.manager import FAILED
+from landscape.client.manager.manager import SUCCEEDED
+from landscape.client.manager.snapservicesmanager import SnapServicesManager
+from landscape.client.snap_http import SnapdHttpException
+from landscape.client.snap_http import SnapdResponse
+from landscape.client.tests.helpers import LandscapeTest
+from landscape.client.tests.helpers import ManagerHelper
+
+
+class SnapServicesManagerTest(LandscapeTest):
+    helpers = [ManagerHelper]
+
+    def setUp(self):
+        super().setUp()
+
+        self.snap_http = mock.patch(
+            "landscape.client.manager.snapservicesmanager.snap_http",
+        ).start()
+
+        self.broker_service.message_store.set_accepted_types(
+            ["operation-result"],
+        )
+        self.plugin = SnapServicesManager()
+        self.manager.add(self.plugin)
+
+        self.manager.config.snapd_poll_attempts = 2
+        self.manager.config.snapd_poll_interval = 0.1
+
+    def tearDown(self):
+        mock.patch.stopall()
+
+    @mock.patch("landscape.client.manager.snapmanager.snap_http")
+    def test_start_service(self, mock_base_snap_http):
+        self.snap_http.start.return_value = SnapdResponse(
+            "async",
+            202,
+            "Accepted",
+            None,
+            change="1",
+        )
+        mock_base_snap_http.check_changes.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [{"id": "1", "status": "Done"}],
+        )
+        self.snap_http.get_apps.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [
+                {
+                    "snap": "test-snap",
+                    "name": "bye-svc",
+                    "daemon": "simple",
+                    "daemon-scope": "system",
+                    "enabled": True,
+                },
+            ],
+        )
+
+        result = self.manager.dispatch_message(
+            {
+                "type": "start-snap-service",
+                "operation-id": 123,
+                "snaps": [
+                    {"name": "test-snap.hello-svc", "args": {"enable": True}},
+                ],
+            },
+        )
+
+        def got_result(_):
+            self.assertMessages(
+                self.broker_service.message_store.get_pending_messages(),
+                [
+                    {
+                        "type": "operation-result",
+                        "status": SUCCEEDED,
+                        "result-text": "{'completed': ['test-snap.hello-svc'],"
+                        " 'errored': [], 'errors': {}}",
+                        "operation-id": 123,
+                    },
+                ],
+            )
+
+        self.snap_http.start.assert_called_once_with(
+            "test-snap.hello-svc",
+            enable=True,
+        )
+
+        return result.addCallback(got_result)
+
+    def test_start_service_error(self):
+        self.snap_http.start.side_effect = SnapdHttpException(
+            b'{"result": "snap idonotexist not found"}',
+        )
+        self.snap_http.get_apps.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [],
+        )
+
+        result = self.manager.dispatch_message(
+            {
+                "type": "start-snap-service",
+                "operation-id": 123,
+                "snaps": [{"name": "idonotexist", "args": {"enable": True}}],
+            },
+        )
+
+        self.log_helper.ignore_errors(r".+idonotexist$")
+
+        def got_result(_):
+            self.assertMessages(
+                self.broker_service.message_store.get_pending_messages(),
+                [
+                    {
+                        "type": "operation-result",
+                        "status": FAILED,
+                        "result-text": "{'completed': [], "
+                        "'errored': [], 'errors': {'idonotexist': "
+                        "'snap idonotexist not found'}}",
+                        "operation-id": 123,
+                    },
+                ],
+            )
+
+        self.snap_http.start.assert_called_once_with(
+            "idonotexist",
+            enable=True,
+        )
+
+        return result.addCallback(got_result)
+
+    @mock.patch("landscape.client.manager.snapmanager.snap_http")
+    def test_stop_service_batch(self, mock_base_snap_http):
+        self.snap_http.stop_all.return_value = SnapdResponse(
+            "async",
+            202,
+            "Accepted",
+            None,
+            change="1",
+        )
+        mock_base_snap_http.check_changes.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [{"id": "1", "status": "Done"}],
+        )
+        self.snap_http.get_apps.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [
+                {
+                    "snap": "lxd",
+                    "name": "lxd",
+                    "daemon": "simple",
+                    "daemon-scope": "system",
+                },
+                {
+                    "snap": "landscape-client",
+                    "name": "landscape-client",
+                    "daemon": "simple",
+                    "daemon-scope": "system",
+                },
+            ],
+        )
+
+        result = self.manager.dispatch_message(
+            {
+                "type": "stop-snap-service",
+                "operation-id": 123,
+                "snaps": [
+                    {"name": "lxd"},
+                    {"name": "landscape-client"},
+                ],
+                "args": {"disable": False},
+            },
+        )
+
+        def got_result(_):
+            self.assertMessages(
+                self.broker_service.message_store.get_pending_messages(),
+                [
+                    {
+                        "type": "operation-result",
+                        "status": SUCCEEDED,
+                        "result-text": "{'completed': ['BATCH'], "
+                        "'errored': [], 'errors': {}}",
+                        "operation-id": 123,
+                    },
+                ],
+            )
+
+        self.snap_http.stop_all.assert_called_once_with(
+            ["lxd", "landscape-client"],
+            disable=False,
+        )
+
+        return result.addCallback(got_result)
+
+    @mock.patch("landscape.client.manager.snapmanager.snap_http")
+    def test_restart_service(self, mock_base_snap_http):
+        self.snap_http.restart_all.return_value = SnapdResponse(
+            "async",
+            202,
+            "Accepted",
+            None,
+            change="1",
+        )
+        mock_base_snap_http.check_changes.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [{"id": "1", "status": "Done"}],
+        )
+        self.snap_http.get_apps.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [
+                {
+                    "snap": "lxd",
+                    "name": "lxd",
+                    "daemon": "simple",
+                    "daemon-scope": "system",
+                },
+                {
+                    "snap": "test-snap",
+                    "name": "bye-svc",
+                    "daemon": "simple",
+                    "daemon-scope": "system",
+                },
+            ],
+        )
+
+        result = self.manager.dispatch_message(
+            {
+                "type": "restart-snap-service",
+                "operation-id": 123,
+                "snaps": [
+                    {"name": "test-snap"},
+                    {"name": "lxd"},
+                ],
+            },
+        )
+
+        def got_result(_):
+            self.assertMessages(
+                self.broker_service.message_store.get_pending_messages(),
+                [
+                    {
+                        "type": "operation-result",
+                        "status": SUCCEEDED,
+                        "result-text": "{'completed': ['BATCH'], "
+                        "'errored': [], 'errors': {}}",
+                        "operation-id": 123,
+                    },
+                ],
+            )
+
+        self.snap_http.restart_all.assert_called_once_with(
+            ["test-snap", "lxd"],
+        )
+
+        return result.addCallback(got_result)
+
+    @mock.patch("landscape.client.manager.snapmanager.snap_http")
+    def test_restart_service_update_failure(self, mock_base_snap_http):
+        """
+        Test when the client runs the operation successfully but
+         `_send_snap_update` fails.
+        """
+        self.snap_http.restart_all.return_value = SnapdResponse(
+            "async",
+            202,
+            "Accepted",
+            None,
+            change="1",
+        )
+        mock_base_snap_http.check_changes.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            [{"id": "1", "status": "Done"}],
+        )
+        self.snap_http.get_apps.side_effect = SnapdHttpException(
+            "An error occurred.",
+        )
+        mock_logger = mock.Mock()
+        self.patch(sys.modules["logging"], "error", mock_logger)
+
+        result = self.manager.dispatch_message(
+            {
+                "type": "restart-snap-service",
+                "operation-id": 123,
+                "snaps": [
+                    {"name": "test-snap"},
+                    {"name": "lxd"},
+                ],
+            },
+        )
+
+        self.log_helper.ignore_errors(r".+error$")
+
+        def got_result(_):
+            self.assertMessages(
+                self.broker_service.message_store.get_pending_messages(),
+                [
+                    {
+                        "type": "operation-result",
+                        "status": SUCCEEDED,
+                        "result-text": "{'completed': ['BATCH'], "
+                        "'errored': [], 'errors': {}}",
+                        "operation-id": 123,
+                    },
+                ],
+            )
+
+            mock_logger.assert_called_once_with(
+                "Unable to list services: An error occurred.",
+            )
+
+        self.snap_http.restart_all.assert_called_once_with(
+            ["test-snap", "lxd"],
+        )
+
+        return result.addCallback(got_result)

--- a/landscape/client/manager/usermanager.py
+++ b/landscape/client/manager/usermanager.py
@@ -20,6 +20,7 @@ class UserManager(ManagerPlugin):
             shadow_file = shadow_file or "/var/lib/extrausers/shadow"
         else:
             management = management or UserManagement()
+            shadow_file = shadow_file
 
         self._management = management
         self._shadow_file = shadow_file

--- a/landscape/client/monitor/config.py
+++ b/landscape/client/monitor/config.py
@@ -23,6 +23,7 @@ ALL_PLUGINS = [
     "LivePatch",
     "UbuntuProRebootRequired",
     "SnapMonitor",
+    "SnapServicesMonitor",
 ]
 
 

--- a/landscape/client/monitor/snapmonitor.py
+++ b/landscape/client/monitor/snapmonitor.py
@@ -19,7 +19,7 @@ class SnapMonitor(DataWatcher):
         # The default interval is 30 minutes.
         self.run_interval = self.config.snap_monitor_interval
 
-        super(SnapMonitor, self).register(registry)
+        super().register(registry)
 
     def get_data(self):
         try:
@@ -40,12 +40,6 @@ class SnapMonitor(DataWatcher):
 
             snaps[i]["config"] = json.dumps(config)
 
-        try:
-            services = snap_http.get_apps(services_only=True).result
-        except SnapdHttpException as e:
-            logging.warning(f"Unable to list services: {e}")
-            services = []
-
         # We get a lot of extra info from snapd. To avoid caching it all
         # or invalidating the cache on timestamp changes, we use Message
         # coercion to strip out the unnecessaries, then sort on the snap
@@ -53,13 +47,9 @@ class SnapMonitor(DataWatcher):
         data = SNAPS.coerce(
             {
                 "type": "snaps",
-                "snaps": {
-                    "installed": snaps,
-                    "services": services,
-                },
+                "snaps": {"installed": snaps},
             },
         )
         data["snaps"]["installed"].sort(key=lambda x: x["id"])
-        data["snaps"]["services"].sort(key=lambda x: x["name"])
 
         return data["snaps"]

--- a/landscape/client/monitor/snapservicesmonitor.py
+++ b/landscape/client/monitor/snapservicesmonitor.py
@@ -1,0 +1,28 @@
+import logging
+
+from landscape.client import snap_http
+from landscape.client.monitor.plugin import DataWatcher
+from landscape.client.snap_http import SnapdHttpException
+
+
+class SnapServicesMonitor(DataWatcher):
+
+    message_type = "snap-services"
+    message_key = "services"
+    persist_name = message_type
+    scope = "snaps"
+
+    def register(self, registry):
+        self.config = registry.config
+        self.run_interval = 60  # 1 minute
+        super().register(registry)
+
+    def get_data(self):
+        try:
+            services = snap_http.get_apps(services_only=True).result
+        except SnapdHttpException as e:
+            logging.warning(f"Unable to list services: {e}")
+            services = []
+        services.sort(key=lambda x: x["name"])
+
+        return {"running": services}

--- a/landscape/client/monitor/tests/test_snapservicesmonitor.py
+++ b/landscape/client/monitor/tests/test_snapservicesmonitor.py
@@ -1,0 +1,112 @@
+from unittest.mock import patch
+
+from landscape.client.monitor.snapservicesmonitor import SnapServicesMonitor
+from landscape.client.snap_http import SnapdHttpException
+from landscape.client.snap_http import SnapdResponse
+from landscape.client.tests.helpers import LandscapeTest
+from landscape.client.tests.helpers import MonitorHelper
+
+
+class SnapServicesMonitorTest(LandscapeTest):
+
+    helpers = [MonitorHelper]
+
+    def setUp(self):
+        super().setUp()
+        self.mstore.set_accepted_types(["snap-services"])
+
+    def test_get_data(self):
+        """Tests getting running snap services data."""
+        plugin = SnapServicesMonitor()
+        self.monitor.add(plugin)
+
+        plugin.exchange()
+
+        messages = self.mstore.get_pending_messages()
+
+        self.assertTrue(len(messages) > 0)
+        self.assertIn("running", messages[0]["services"])
+
+    @patch("landscape.client.monitor.snapservicesmonitor.snap_http")
+    def test_get_snap_services(self, snap_http_mock):
+        """Tests that we can get and coerce snap services."""
+        plugin = SnapServicesMonitor()
+        self.monitor.add(plugin)
+        self.maxDiff = None
+
+        services = [
+            {
+                "snap": "test-snap",
+                "name": "bye-svc",
+                "daemon": "simple",
+                "daemon-scope": "system",
+            },
+            {
+                "snap": "test-snap",
+                "name": "hello-svc",
+                "daemon": "simple",
+                "daemon-scope": "system",
+                "active": True,
+            },
+            {
+                "activators": [
+                    {
+                        "Active": True,
+                        "Enabled": True,
+                        "Name": "unix",
+                        "Type": "socket",
+                    },
+                ],
+                "daemon": "simple",
+                "daemon-scope": "system",
+                "enabled": True,
+                "name": "user-daemon",
+                "snap": "lxd",
+            },
+        ]
+        snap_http_mock.list.return_value = SnapdResponse("sync", 200, "OK", [])
+        snap_http_mock.get_conf.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            {},
+        )
+        snap_http_mock.get_apps.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            services,
+        )
+        plugin.exchange()
+
+        messages = self.mstore.get_pending_messages()
+
+        self.assertTrue(len(messages) > 0)
+        self.assertCountEqual(messages[0]["services"]["running"], services)
+
+    @patch("landscape.client.monitor.snapservicesmonitor.snap_http")
+    def test_get_snap_services_error(self, snap_http_mock):
+        """Tests that we can get and coerce snap services."""
+        plugin = SnapServicesMonitor()
+        self.monitor.add(plugin)
+
+        snap_http_mock.list.return_value = SnapdResponse("sync", 200, "OK", [])
+        snap_http_mock.get_conf.return_value = SnapdResponse(
+            "sync",
+            200,
+            "OK",
+            {},
+        )
+
+        with self.assertLogs(level="WARNING") as cm:
+            snap_http_mock.get_apps.side_effect = SnapdHttpException
+            plugin.exchange()
+
+        messages = self.mstore.get_pending_messages()
+
+        self.assertTrue(len(messages) > 0)
+        self.assertEqual(
+            cm.output,
+            ["WARNING:root:Unable to list services: "],
+        )
+        self.assertCountEqual(messages[0]["services"]["running"], [])

--- a/landscape/message_schemas/server_bound.py
+++ b/landscape/message_schemas/server_bound.py
@@ -803,7 +803,17 @@ SNAPS = Message(
                         ],
                     ),
                 ),
-                "services": List(
+            },
+        ),
+    },
+)
+
+SNAP_SERVICES = Message(
+    "snap-services",
+    {
+        "services": KeyDict(
+            {
+                "running": List(
                     KeyDict(
                         {
                             "name": Unicode(),
@@ -830,7 +840,7 @@ SNAPS = Message(
                     ),
                 ),
             },
-            optional=["services"],
+            strict=False,
         ),
     },
 )
@@ -883,4 +893,5 @@ message_schemas = (
     UBUNTU_PRO_REBOOT_REQUIRED,
     SNAPS,
     SNAP_INFO,
+    SNAP_SERVICES,
 )

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -20,8 +20,8 @@ url = ${_url}/message-system
 ping_url = ${_url}/ping
 log_level = info
 script_users = ALL
-manager_plugins = ProcessKiller,UserManager,ShutdownManager,HardwareInfo,KeystoneToken,SnapManager,ScriptExecution
-monitor_plugins = ActiveProcessInfo,ComputerInfo,LoadAverage,MemoryInfo,MountInfo,ProcessorInfo,Temperature,UserMonitor,RebootRequired,NetworkActivity,NetworkDevice,CPUUsage,SwiftUsage,CephUsage,ComputerTags,SnapMonitor
+manager_plugins = ProcessKiller,UserManager,ShutdownManager,HardwareInfo,KeystoneToken,SnapManager,SnapServicesManager,ScriptExecution
+monitor_plugins = ActiveProcessInfo,ComputerInfo,LoadAverage,MemoryInfo,MountInfo,ProcessorInfo,Temperature,UserMonitor,RebootRequired,NetworkActivity,NetworkDevice,CPUUsage,SwiftUsage,CephUsage,ComputerTags,SnapMonitor,SnapServicesMonitor
 EOF
 
 if [ -n "$_access_group" ]; then


### PR DESCRIPTION
~Makes sure the extra `services` field doesn't trip up the server after the next landscape server release~