### PR TITLE
fix: add missing build packages to the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,6 +75,12 @@ parts:
       - python3-dev
       - python3-distutils-extra
       - python3-twisted
+      - python3-pycurl
+      - python3-netifaces
+      - python3-yaml
+      - ubuntu-advantage-tools
+      - locales-all
+      - python3-dbus
     override-build: |
       git commit -n -a -m "dev build for snap" --no-gpg-sign --allow-empty
       cat << EOF > debian/changelog


### PR DESCRIPTION
When running `make snap-debug`, we're getting the following error:

```
:: dpkg-checkbuilddeps: error: Unmet build dependencies: python3-pycurl python3-netifaces python3-yaml ubuntu-advantage-tools locales-all python3-dbus
:: dpkg-buildpackage: warning: build dependencies/conflicts unsatisfied; aborting
:: dpkg-buildpackage: warning: (Use -d flag to override.)
```

Likely due to the extra dependencies added here:
```
Build-Depends: debhelper (>= 11), po-debconf, libdistro-info-perl,
               dh-python, python3-dev, python3-distutils-extra,
               lsb-release, gawk, net-tools,
               python3-apt, python3-twisted, python3-configobj,
               python3-pycurl, python3-netifaces, python3-yaml,
               ubuntu-advantage-tools, locales-all, python3-dbus
```