### PR TITLE
fix(ProcessKiller): add process-control interface to the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,6 +39,7 @@ apps:
       - snapd-control
       - system-observe
       - account-control
+      - process-control
   config:
     command: usr/bin/landscape-config
     plugs: [network]


### PR DESCRIPTION
This will allow us to kill and end processes through the snap.

The before & after:

![image](https://github.com/canonical/landscape-client/assets/43380836/6248f69d-f483-4702-a473-5d46b6eb65f3)
