### PR TITLE
chore(snap make targets): remove hardcoded snap version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,8 @@ etags:
 	-etags --languages=python -R .
 
 snap-install:
-	sudo snap install --devmode landscape-client_0.1_amd64.snap
+	$(eval VERSION=$(shell yq ".version" snap/snapcraft.yaml))
+	sudo snap install --devmode landscape-client_$(VERSION)_amd64.snap
 .PHONY: snap-install
 
 snap-remote-build:
@@ -126,8 +127,9 @@ snap-debug:
 .PHONY: snap-debug
 
 snap-clean: snap-remove
+	$(eval VERSION=$(shell yq ".version" snap/snapcraft.yaml))
 	$(SNAPCRAFT) clean
-	-rm landscape-client_0.1_amd64.snap
+	-rm landscape-client_$(VERSION)_amd64.snap
 .PHONY: snap-clean
 
 snap:

--- a/README
+++ b/README
@@ -120,6 +120,13 @@ snap container in the event of an error:
 $ make snap-debug
 ```
 
+To use the make targets below, make sure you have [yq](https://github.com/mikefarah/yq) installed. You can install it using [Homebrew](https://brew.sh/) or as a snap:
+
+```console
+$ brew install yq
+$ snap install yq
+```
+
 To install the resulting snap:
 ```
 $ make snap-install


### PR DESCRIPTION
The snap version for the `snap-install` & `snap-clean` make targets is fixed to `0.1`. This change will ensure that it changes dynamically as the `snapcraft.yaml` file evolves.

Developers are required to install [yq](https://github.com/mikefarah/yq) on their machine.
