### PR TITLE
fix ubuntu pro info on registration

### DIFF
--- a/landscape/client/broker/registration.py
+++ b/landscape/client/broker/registration.py
@@ -8,11 +8,13 @@ the machinery in this module will notice that we have no identification
 credentials yet and that the server accepts registration messages, so it
 will craft an appropriate one and send it out.
 """
+import json
 import logging
 
 from twisted.internet.defer import Deferred
 
 from landscape.client.broker.exchange import maybe_bytes
+from landscape.client.manager.ubuntuproinfo import get_ubuntu_pro_info
 from landscape.lib.juju import get_juju_info
 from landscape.lib.network import get_fqdn
 from landscape.lib.tag import is_valid_tag_list
@@ -238,6 +240,8 @@ class RegistrationHandler:
         with_word = "with" if bool(registration_key) else "without"
         with_tags = f"and tags {tags} " if tags else ""
         with_group = f"in access group '{group}' " if group else ""
+
+        message["ubuntu_pro_info"] = json.dumps(get_ubuntu_pro_info())
 
         logging.info(
             f"Queueing message to register with account {account_name!r} "

--- a/landscape/client/broker/tests/test_registration.py
+++ b/landscape/client/broker/tests/test_registration.py
@@ -660,6 +660,16 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         messages = self.mstore.get_pending_messages()
         self.assertEqual(socket.getfqdn(), messages[0]["hostname"])
 
+    def test_ubuntu_pro_info_present_in_registration(self):
+        """Ubuntu Pro info is included to handle licensing in Server"""
+        self.mstore.set_server_api(b"3.3")
+        self.mstore.set_accepted_types(["register"])
+        self.config.computer_title = "Computer Title"
+        self.config.account_name = "account_name"
+        self.reactor.fire("pre-exchange")
+        messages = self.mstore.get_pending_messages()
+        self.assertIn("ubuntu_pro_info", messages[0])
+
 
 class JujuRegistrationHandlerTest(RegistrationHandlerTestBase):
 


### PR DESCRIPTION
A fix (#215) to incorrect Livepatch reporting unintentionally removed Ubuntu Pro info during registration.  This reverts that change.