### PR TITLE
Permit Core devices to be managed by Landscape

### DIFF
--- a/landscape/client/broker/tests/test_registration.py
+++ b/landscape/client/broker/tests/test_registration.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import socket
-from datetime import datetime
 from unittest import mock
 
 from landscape.client.broker.registration import Identity
@@ -678,30 +677,21 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         during the registration message
         """
 
-        def datetime_is_aware(d):
-            """https://docs.python.org/3/library/datetime.html#determining-if-an-object-is-aware-or-naive"""  # noqa
-            return d.tzinfo is not None and d.tzinfo.utcoffset(d) is not None
-
         self.mstore.set_server_api(b"3.3")
         self.mstore.set_accepted_types(["register"])
         self.config.computer_title = "Computer Title"
         self.config.account_name = "account_name"
-
         self.reactor.fire("pre-exchange")
+
         messages = self.mstore.get_pending_messages()
 
-        # verify the strictly necessary fields that Server expects
+        # verify the minimum necessary fields that Server expects
         self.assertIn("ubuntu_pro_info", messages[0])
         ubuntu_pro_info = json.loads(messages[0]["ubuntu_pro_info"])
         self.assertIn("effective", ubuntu_pro_info)
         self.assertIn("expires", ubuntu_pro_info)
         contract = ubuntu_pro_info["contract"]
         self.assertIn("landscape", contract["products"])
-
-        expires = datetime.fromisoformat(ubuntu_pro_info["expires"])
-        effective = datetime.fromisoformat(ubuntu_pro_info["effective"])
-        self.assertTrue(datetime_is_aware(expires))
-        self.assertTrue(datetime_is_aware(effective))
 
 
 class JujuRegistrationHandlerTest(RegistrationHandlerTestBase):

--- a/landscape/client/manager/ubuntuproinfo.py
+++ b/landscape/client/manager/ubuntuproinfo.py
@@ -1,5 +1,8 @@
 import json
 import subprocess
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 from pathlib import Path
 
 from landscape.client import IS_CORE
@@ -65,10 +68,7 @@ def get_ubuntu_pro_info() -> dict:
     indicating this.
     """
     if IS_CORE:
-        return _ubuntu_pro_error_message(
-            "Ubuntu Pro is not available on Ubuntu Core.",
-            "core-unsupported",
-        )
+        return _get_core_ubuntu_pro_info()
 
     try:
         completed_process = subprocess.run(
@@ -99,4 +99,70 @@ def _ubuntu_pro_error_message(message: str, code: str) -> dict:
             },
         ],
         "result": "failure",
+    }
+
+
+def _get_core_ubuntu_pro_info():
+    """Mock Ubuntu Pro info for a Core distribution"""
+    return {
+        "_doc": (
+            "Content provided in json response is currently considered "
+            "Experimental and may change"
+        ),
+        "_schema_version": "0.1",
+        "account": {
+            "created_at": "",
+            "external_account_ids": [],
+            "id": "",
+            "name": "",
+        },
+        "attached": False,
+        "config": {
+            "contract_url": "https://contracts.canonical.com",
+            "data_dir": "/var/lib/ubuntu-advantage",
+            "log_file": "/var/log/ubuntu-advantage.log",
+            "log_level": "debug",
+            "security_url": "https://ubuntu.com/security",
+            "ua_config": {
+                "apt_news": False,
+                "apt_news_url": "https://motd.ubuntu.com/aptnews.json",
+                "global_apt_http_proxy": None,
+                "global_apt_https_proxy": None,
+                "http_proxy": None,
+                "https_proxy": None,
+                "metering_timer": 14400,
+                "ua_apt_http_proxy": None,
+                "ua_apt_https_proxy": None,
+                "update_messaging_timer": 21600,
+            },
+        },
+        "config_path": "/etc/ubuntu-advantage/uaclient.conf",
+        "contract": {
+            "created_at": "",
+            "id": "",
+            "name": "",
+            "products": ["landscape"],
+            "tech_support_level": "n/a",
+        },
+        "effective": datetime.now(tz=timezone.utc).isoformat(),
+        "environment_vars": [],
+        "errors": [],
+        "execution_details": "No Ubuntu Pro operations are running",
+        "execution_status": "inactive",
+        "expires": (datetime.now(tz=timezone.utc) + timedelta(30)).isoformat(),
+        "features": {},
+        "machine_id": None,
+        "notices": [],
+        "result": "success",
+        "services": [
+            {
+                "available": "yes",
+                "description": "Management and administration tool for Ubuntu",
+                "description_override": None,
+                "name": "landscape",
+            },
+        ],
+        "simulated": False,
+        "version": "31.1",
+        "warnings": [],
     }


### PR DESCRIPTION
Include Ubuntu Pro info such that Core devices may register with Landscape under a full Ubuntu Pro license.

To test manually, either spin up a Core instance or set `IS_CORE` in `landscape.client.__init__` to `True`.  Register with server and confirm that the client may be accepted and placed into an Ubuntu Pro full license.