### PR TITLE
Add network-manager and network-control plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,6 +40,8 @@ apps:
       - system-observe
       - account-control
       - process-control
+      - network-control
+      - network-manager
   config:
     command: usr/bin/landscape-config
     plugs: [network]


### PR DESCRIPTION
Added network-manager and network-control plugs to the snap. This is for the D'crypt edge case and will need to be manually connected. We do not have any plans to ask for auto-connection at this stage.