### PR TITLE
allow changing the landscape snap config using snap set

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,3 +1,52 @@
-#!/bin/sh -e
+#!/usr/bin/env python3
 
-# Do nothing for now
+import subprocess
+
+from landscape.client.deployment import Configuration
+
+
+def _snapctl(action, setting):
+    snapctl = subprocess.run(
+        ["snapctl", action, setting],
+        capture_output=True,
+        text=True,
+    )
+    return snapctl.stdout
+
+
+config = Configuration()
+config.load([])
+
+config_entries = [
+    # (snapctl key, landscape client config key, mapping function)
+    ("account-name", "account_name", None),
+    ("computer-title", "computer_title", None),
+    ("landscape-url", "url", lambda url: f"{url}/message-system"),
+    ("landscape-url", "ping_url", lambda url: f"{url}/ping"),
+    ("log-level", "log_level", None),
+    ("script-users", "script_users", None),
+    ("manager-plugins", "manager_plugins", None),
+    ("monitor-plugins", "monitor_plugins", None),
+    ("access-group", "access_group", None),
+    ("registration-key", "registration_key", None),
+]
+
+changed = set()
+for snapctl_key, landscape_key, mapping_fn in config_entries:
+    value = _snapctl("get", snapctl_key).strip()
+    if not value:
+        # empty, value not has not changed
+        continue
+
+    if mapping_fn:
+        value = mapping_fn(value)
+
+    setattr(config, landscape_key, value)
+    changed.add(snapctl_key)
+
+config.write()
+
+# unset the values from snapctl so that in the next run
+#  we know what has changed
+# the landscape-client.conf file is still the main source of truth
+_snapctl("unset", " ".join(changed))

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -7,9 +7,29 @@ _account=$(snapctl get account-name)
 _registration_key=$(snapctl get registration-key)
 _title=$(snapctl get computer-title)
 _url=$(snapctl get landscape-url)
+_log_level=$(snapctl get log-level)
+_script_users=$(snapctl get script-users)
+_manager_plugins=$(snapctl get manager-plugins)
+_monitor_plugins=$(snapctl get monitor-plugins)
 
 if [ -z "$_url" ]; then
   _url="https://landscape.canonical.com"
+fi
+
+if [ -z "$_log_level" ]; then
+    _log_level="info"
+fi
+
+if [ -z "$_script_users" ]; then
+    _script_users="ALL"
+fi
+
+if [ -z "$_manager_plugins" ]; then
+    _manager_plugins="ProcessKiller,UserManager,ShutdownManager,HardwareInfo,KeystoneToken,SnapManager,SnapServicesManager,ScriptExecution"
+fi
+
+if [ -z "$_monitor_plugins" ]; then
+    _monitor_plugins="ActiveProcessInfo,ComputerInfo,LoadAverage,MemoryInfo,MountInfo,ProcessorInfo,Temperature,UserMonitor,RebootRequired,NetworkActivity,NetworkDevice,CPUUsage,SwiftUsage,CephUsage,ComputerTags,SnapMonitor,SnapServicesMonitor"
 fi
 
 cat > "$CLIENT_CONF" << EOF
@@ -18,10 +38,10 @@ account_name = $_account
 computer_title = $_title
 url = ${_url}/message-system
 ping_url = ${_url}/ping
-log_level = info
-script_users = ALL
-manager_plugins = ProcessKiller,UserManager,ShutdownManager,HardwareInfo,KeystoneToken,SnapManager,SnapServicesManager,ScriptExecution
-monitor_plugins = ActiveProcessInfo,ComputerInfo,LoadAverage,MemoryInfo,MountInfo,ProcessorInfo,Temperature,UserMonitor,RebootRequired,NetworkActivity,NetworkDevice,CPUUsage,SwiftUsage,CephUsage,ComputerTags,SnapMonitor,SnapServicesMonitor
+log_level = $_log_level
+script_users = $_script_users
+manager_plugins = $_manager_plugins
+monitor_plugins = $_monitor_plugins
 EOF
 
 if [ -n "$_access_group" ]; then


### PR DESCRIPTION
This will allow us to change the `landscape-client.conf` config file using snap set.

`snap set` doesn't allow us to view the previous value of the config so we have to clean up the snap config to detect changes on the next run. Unsetting the values helps us avoid conflicts with configuration written through `landscape-client.config`.

It also expands the range of options that can be set. For instance, it's now possible to configure the plugins when using a gadget snap.

Please note that the landscape-client service needs to be restarted after config changes.

Issue reported by @dilyn-corner
