### PR TITLE
d/landscape-sysinfo.wrapper fix case on CORES variable

### DIFF
--- a/debian/landscape-sysinfo.wrapper
+++ b/debian/landscape-sysinfo.wrapper
@@ -19,7 +19,7 @@ else
     export LANG
     CORES=$(grep -c ^processor /proc/cpuinfo 2>/dev/null)
     [ "$CORES" -eq "0" ] && CORES=1
-    THRESHOLD="${cores:-1}.0"
+    THRESHOLD="${CORES:-1}.0"
 
     if [ $(echo "`cut -f1 -d ' ' /proc/loadavg` < $THRESHOLD" | bc) -eq 1 ]; then
         SYSINFO=$(printf "\n System information as of %s\n\n%s\n" \


### PR DESCRIPTION
Incorrect reference to the `CORES` variable meant that `THRESHOLD` was always `1.0`. Not entirely fatal to the sysinfo script, but does significantly change the odds whether the system is deemed to have too high a load to collect sysinfo.