### PR TITLE
Update snapcraft.yaml to grade:stable to permit snap promotion.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   in a Landscape account. It provides the Landscape client and requires a
   Landscape account.
 
-grade: devel # must be 'stable' to release into candidate/stable channels
+grade: stable # must be 'stable' to release into candidate/stable channels
 architectures:
   - build-on: [amd64]
   - build-on: [arm64]


### PR DESCRIPTION
This change is needed to allow us to promote the snap to the latest stable channel.
