### PR TITLE
chore: update remote for snap-http submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "snap-http"]
 	path = snap-http
-	url = https://github.com/Perfect5th/snap-http
+	url = https://github.com/canonical/snap-http


### PR DESCRIPTION
Noticed that `snap-http` was moved to https://github.com/canonical/snap-http hence the update.

`checkout` on CI okay:
![image](https://github.com/canonical/landscape-client/assets/43380836/ba98d45a-4c1e-43f9-b525-ab78b9c4dd82)
