### PR TITLE
include deb822 sources when collecting source channels (LP: #2062561)

### DIFF
--- a/landscape/lib/apt/package/facade.py
+++ b/landscape/lib/apt/package/facade.py
@@ -282,10 +282,16 @@ class AptFacade:
             return
         self.reload_channels()
 
+    @property
+    def _sourceparts_directory(self):
+        return apt_pkg.config.find_dir("Dir::Etc::sourceparts")
+
     def _get_internal_sources_list(self):
         """Return the path to the source.list file for the facade channels."""
-        sources_dir = apt_pkg.config.find_dir("Dir::Etc::sourceparts")
-        return os.path.join(sources_dir, "_landscape-internal-facade.list")
+        return os.path.join(
+            self._sourceparts_directory,
+            "_landscape-internal-facade.list",
+        )
 
     def add_channel_apt_deb(
         self,
@@ -358,6 +364,10 @@ class AptFacade:
         and type keys.
         """
         sources_list = SourcesList()
+        if hasattr(sources_list, "deb822"):
+            sources_list.deb822 = True
+            sources_list.refresh()
+
         return [
             {
                 "baseurl": entry.uri,
@@ -372,6 +382,10 @@ class AptFacade:
     def reset_channels(self):
         """Remove all the configured channels."""
         sources_list = SourcesList()
+        if hasattr(sources_list, "deb822"):
+            sources_list.deb822 = True
+            sources_list.refresh()
+
         for entry in sources_list:
             entry.set_enabled(False)
         sources_list.save()

--- a/landscape/lib/apt/package/testing.py
+++ b/landscape/lib/apt/package/testing.py
@@ -15,6 +15,7 @@ class AptFacadeHelper:
 
     def set_up(self, test_case):
         test_case.apt_root = test_case.makeDir()
+        os.makedirs(os.path.join(test_case.apt_root, "etc/apt/preferences.d"))
         self.dpkg_status = os.path.join(
             test_case.apt_root,
             "var",

--- a/landscape/lib/apt/package/tests/test_facade.py
+++ b/landscape/lib/apt/package/tests/test_facade.py
@@ -6,6 +6,7 @@ import unittest
 import weakref
 from collections import namedtuple
 from unittest import mock
+from unittest import skipIf
 
 import apt
 import apt_pkg
@@ -595,6 +596,7 @@ class AptFacadeTest(
             self.facade.get_channels(),
         )
 
+    @skipIf(not hasattr(SourcesList(), "deb822"), "aptsources version too old")
     def test_get_channels_deb822(self):
         """`get_channels` includes *.source files with deb822 format."""
         sourceparts_dir = self.facade._sourceparts_directory

--- a/landscape/lib/apt/package/tests/test_facade.py
+++ b/landscape/lib/apt/package/tests/test_facade.py
@@ -595,6 +595,43 @@ class AptFacadeTest(
             self.facade.get_channels(),
         )
 
+    def test_get_channels_deb822(self):
+        """`get_channels` includes *.source files with deb822 format."""
+        sourceparts_dir = self.facade._sourceparts_directory
+        sources_file_path = os.path.join(
+            sourceparts_dir,
+            "test_deb822.sources",
+        )
+
+        with open(sources_file_path, "w") as sources_file:
+            sources_file.write(
+                textwrap.dedent(
+                    """\
+                Types: deb
+                URIs: http://test.archive.ubuntu.com/ubuntu/
+                Suites: unicorn-test
+                Components: main restricted universe multiverse
+                Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+                """,
+                ),
+            )
+
+        channels = self.facade.get_channels()
+
+        self.assertEqual(
+            [
+                {
+                    "baseurl": "http://test.archive.ubuntu.com/ubuntu/",
+                    "components": "main restricted universe multiverse",
+                    "distribution": "unicorn-test",
+                    "type": "deb",
+                },
+            ],
+            channels,
+        )
+
+        os.remove(sources_file_path)
+
     def test_reset_channels(self):
         """
         C{reset_channels()} disables all the configured deb URLs.


### PR DESCRIPTION
See https://bugs.launchpad.net/landscape-client/+bug/2062561 for more context.

The dependency used to collect APT source info, `aptsources`, added support for deb822-formatted `.sources` files, but this support is "opt-in" via a flag passed to the `SourceList` during instantiation.

This kwarg flag doesn't exist in older versions, so using it directly would break on jammy (and earlier), so this change instead sets the attribute after instantiation and re-collects the sources if it does.

Please manually run the tests on noble daily, as we don't have a github runner to do so yet.