### PR TITLE
Fix setlocale for reporter.py

### DIFF
--- a/landscape/client/package/reporter.py
+++ b/landscape/client/package/reporter.py
@@ -942,7 +942,7 @@ class FakeReporter(PackageReporter):
 def main(args):
     # Force UTF-8 encoding only for the reporter, thus allowing libapt-pkg to
     # return unmangled descriptions.
-    locale.setlocale(locale.LC_CTYPE, ("C", "UTF-8"))
+    locale.setlocale(locale.LC_CTYPE, "C")
 
     if "FAKE_GLOBAL_PACKAGE_STORE" in os.environ:
         return run_task_handler(FakeGlobalReporter, args)


### PR DESCRIPTION
landscape-package-reporter did not work on ubuntu 22.04 and 20.04 lxc containers provided by proxmox.

The execution of the setlocal function throw this error
```python
>>> locale.setlocale(locale.LC_CTYPE, ("C", "UTF-8"))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.8/locale.py", line 608, in setlocale
    return _setlocale(category, locale)
locale.Error: unsupported locale setting
```

This change let the execution be compatible on both vm and lxc with Ubuntu 20.04 and 22.04