### PR TITLE
Add non-filtered interfaces to the API response (LP: #2052834)

### DIFF
--- a/landscape/lib/tests/test_network.py
+++ b/landscape/lib/tests/test_network.py
@@ -46,8 +46,12 @@ class NetworkInfoTest(BaseTestCase):
         }
 
         for device in device_info:
-            if device["mac_address"] == "00:00:00:00:00:00":
+            if (
+                device["mac_address"] == "00:00:00:00:00:00"
+                or device["ip_address"] == "0.0.0.0"
+            ):
                 continue
+            print("result is: ", result)
             self.assertIn(device["interface"], result)
             block = interface_blocks[device["interface"]]
             self.assertIn(device["netmask"], block)
@@ -146,8 +150,21 @@ class NetworkInfoTest(BaseTestCase):
         }
 
         device_info = get_active_device_info(extended=False)
-
-        self.assertEqual(device_info, [])
+        self.assertEqual(
+            device_info,
+            [
+                {
+                    "interface": "test_iface",
+                    "flags": 4163,
+                    "speed": 100,
+                    "duplex": True,
+                    "ip_address": "0.0.0.0",
+                    "mac_address": "aa:bb:cc:dd:ee:f0",
+                    "broadcast_address": "0.0.0.0",
+                    "netmask": "0.0.0.0",
+                },
+            ],
+        )
 
     @patch("landscape.lib.network.get_network_interface_speed")
     @patch("landscape.lib.network.get_flags")
@@ -169,7 +186,6 @@ class NetworkInfoTest(BaseTestCase):
         }
 
         device_info = get_active_device_info(extended=True)
-
         self.assertEqual(
             device_info,
             [
@@ -266,7 +282,7 @@ class NetworkInfoTest(BaseTestCase):
     @patch("landscape.lib.network.get_flags")
     @patch("landscape.lib.network.netifaces.ifaddresses")
     @patch("landscape.lib.network.netifaces.interfaces")
-    def test_skip_iface_down(
+    def test_iface_down(
         self,
         mock_interfaces,
         mock_ifaddresses,
@@ -282,7 +298,7 @@ class NetworkInfoTest(BaseTestCase):
         }
         device_info = get_active_device_info()
         interfaces = [i["interface"] for i in device_info]
-        self.assertNotIn("test_iface", interfaces)
+        self.assertEqual(["test_iface"], interfaces)
 
     @patch("landscape.lib.network.get_network_interface_speed")
     @patch("landscape.lib.network.get_flags")

--- a/landscape/lib/tests/test_network.py
+++ b/landscape/lib/tests/test_network.py
@@ -51,7 +51,6 @@ class NetworkInfoTest(BaseTestCase):
                 or device["ip_address"] == "0.0.0.0"
             ):
                 continue
-            print("result is: ", result)
             self.assertIn(device["interface"], result)
             block = interface_blocks[device["interface"]]
             self.assertIn(device["netmask"], block)
@@ -289,6 +288,9 @@ class NetworkInfoTest(BaseTestCase):
         mock_get_flags,
         mock_get_network_interface_speed,
     ):
+        """
+        Make sure interfaces in the 'down' state are also reported
+        """
         mock_get_network_interface_speed.return_value = (100, True)
         mock_get_flags.return_value = 0
         mock_interfaces.return_value = ["test_iface"]


### PR DESCRIPTION
Currently not all interfaces show up in the API response (interfaces with no IP address, in the down state, etc...). 
This patch makes any interface that is not filtered out and has a valid MAC address show up in the API response. All previously included interfaces will still show up as expected.

Mainly interfaces in the down state as well as interfaces in the up state but with no IP address assigned to them will now show up in the API response as long as they have a MAC address. 
The IP address, broadcast address and net-mask for these interfaces will be set to `0.0.0.0`.