### PR TITLE
Fixed Login exit when configuring "refresh every login" on debian

### DIFF
--- a/debian/landscape-sysinfo.wrapper
+++ b/debian/landscape-sysinfo.wrapper
@@ -43,5 +43,3 @@ else
 
     printf "%s\n" "$SYSINFO"
 fi
-
-exit 0


### PR DESCRIPTION
# Issue description
When configuring **"Run sysinfo on every login"** on Debian, the wrapper script is symlinked to /etc/profile.d, but files in there get sourced, not executed. That results in executing `exit 0` from the wrapper script `landscape-sysinfo.wrapper` in the login-shell directly causing it to end immediately on login.

# How to repoduce:
1. setup standard debian
2. install landscape-common as described in [README.md](https://github.com/canonical/landscape-client?tab=readme-ov-file#add-repo-to-a-debian-based-series-that-is-not-ubuntu-experimental)
3. If the configuration-window is shown, **setup "Run sysinfo on every login"** 
  (run `dpkg-reconfigure landscape-common`, if the configuration window is not shown)

Now if another shell tries to log in (who is irrelevant), the shell prints the sysinfo and immediatly after it closes the shell.

Just removing the `exit 0` is sufficient and should not cause any trouble, i think.