### PR TITLE
fix: allow for oracular version of pycurl error string (LP: 2068050)

### DIFF
--- a/landscape/client/broker/tests/test_transport.py
+++ b/landscape/client/broker/tests/test_transport.py
@@ -197,6 +197,8 @@ class HTTPTransportTest(LandscapeTest):
             self.assertIs(r.request, None)
             self.assertIs(r.content, None)
             logfile_value = self.logfile.getvalue()
+            # pycurl error messages vary by version.
+            # First is for <= noble, second for > noble.
             self.assertTrue(
                 "server certificate verification failed" in logfile_value
                 or "SSL certificate problem" in logfile_value,

--- a/landscape/client/broker/tests/test_transport.py
+++ b/landscape/client/broker/tests/test_transport.py
@@ -196,9 +196,10 @@ class HTTPTransportTest(LandscapeTest):
         def got_result(ignored):
             self.assertIs(r.request, None)
             self.assertIs(r.content, None)
+            logfile_value = self.logfile.getvalue()
             self.assertTrue(
-                "server certificate verification failed"
-                in self.logfile.getvalue(),
+                "server certificate verification failed" in logfile_value
+                or "SSL certificate problem" in logfile_value,
             )
 
         result.addErrback(got_result)


### PR DESCRIPTION
https://bugs.launchpad.net/landscape-client/+bug/2068050

The version of pycurl/curl in oracular emits a different error string when self-signed cert validation fails. This causes this test to fail.