### PR TITLE
fix: revert fix for (LP: #1827857)

### DIFF
--- a/landscape/client/monitor/packagemonitor.py
+++ b/landscape/client/monitor/packagemonitor.py
@@ -162,7 +162,7 @@ class PackageMonitor(MonitorPlugin):
         Remove all tasks *except* the resynchronize task.  This is
         because if we clear all tasks, then add the resynchronize,
         it's possible that the reporter may be running a task at this
-        time and when it finishes, it will unknowningly remove the
+        time and when it finishes, it will unknowingly remove the
         resynchronize task because sqlite resets its serial primary
         keys when you delete an entire table.  This problem is avoided
         by adding the task first and removing them all *except* the

--- a/landscape/client/package/reporter.py
+++ b/landscape/client/package/reporter.py
@@ -3,7 +3,6 @@ try:
 except ImportError:
     import urllib.parse as urlparse
 
-import locale
 import logging
 import time
 import os
@@ -940,10 +939,6 @@ class FakeReporter(PackageReporter):
 
 
 def main(args):
-    # Force UTF-8 encoding only for the reporter, thus allowing libapt-pkg to
-    # return unmangled descriptions.
-    locale.setlocale(locale.LC_CTYPE, ("C", "UTF-8"))
-
     if "FAKE_GLOBAL_PACKAGE_STORE" in os.environ:
         return run_task_handler(FakeGlobalReporter, args)
     elif "FAKE_PACKAGE_STORE" in os.environ:

--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -1,4 +1,3 @@
-import locale
 import logging
 import os
 import shutil
@@ -1442,34 +1441,6 @@ class PackageReporterAptTest(LandscapeTest):
             m.return_value = "RESULT"
             self.assertEqual("RESULT", main(["ARGS"]))
         m.assert_called_once_with(PackageReporter, ["ARGS"])
-
-    def test_main_resets_locale(self):
-        """
-        Reporter entry point should reset encoding to utf-8, as libapt-pkg
-        encodes description with system encoding and python-apt decodes
-        them as utf-8 (LP: #1827857).
-        """
-        self._add_package_to_deb_dir(
-            self.repository_dir,
-            "gosa",
-            description="GOsa\u00B2",
-        )
-        self.facade.reload_channels()
-
-        # Set the only non-utf8 locale which we're sure exists.
-        # It behaves slightly differently than the bug, but fails on the
-        # same condition.
-        locale.setlocale(locale.LC_CTYPE, (None, None))
-        self.addCleanup(locale.resetlocale)
-
-        with mock.patch("landscape.client.package.reporter.run_task_handler"):
-            main([])
-
-        # With the actual package, the failure will occur looking up the
-        # description translation.
-        pkg = self.facade.get_packages_by_name("gosa")[0]
-        skel = self.facade.get_package_skeleton(pkg, with_info=True)
-        self.assertEqual("GOsa\u00B2", skel.description)
 
     def test_find_reporter_command_with_bindir(self):
         self.config.bindir = "/spam/eggs"

--- a/landscape/lib/apt/package/tests/test_skeleton.py
+++ b/landscape/lib/apt/package/tests/test_skeleton.py
@@ -1,4 +1,3 @@
-import locale
 import unittest
 
 from twisted.python.compat import unicode
@@ -193,15 +192,8 @@ class SkeletonAptTest(BaseTestCase):
     def test_build_skeleton_with_unicode_and_non_ascii(self):
         """
         If with_unicode and with_info are passed to build_skeleton_apt,
-        the description is decoded.
+        the description is decoded and non-ascii chars replaced.
         """
-        # Py2 used to convert to lossy ascii (thus LC_ in Makefile)
-        # Py3 doesn't, and python3-apt assumes UTF8 (LP: #1827857).
-        # If you revisit this test, also check reporter.main(), which
-        # should set this globally to the reporter process.
-        locale.setlocale(locale.LC_CTYPE, "C.UTF-8")
-        self.addCleanup(locale.resetlocale)
-
         self._add_package_to_deb_dir(
             self.skeleton_repository_dir,
             "pkg",
@@ -211,7 +203,7 @@ class SkeletonAptTest(BaseTestCase):
         self.facade._cache.open(None)
         pkg = self.get_package("pkg")
         skeleton = build_skeleton_apt(pkg, with_unicode=True, with_info=True)
-        self.assertEqual("T\u00E9st", skeleton.description)
+        self.assertEqual("T?st", skeleton.description)
 
     def test_build_skeleton_minimal(self):
         """


### PR DESCRIPTION
The fix was implemented in the `python3-apt` package. The changes in `landscape-client` now cause issues with package reporter on machines with certain locale configurations.