### PR TITLE
fix: retry setting the computer title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ landscape-client_ppc64el*.txt
 landscape-client_s390x*.txt
 landscape_client.egg-info
 .pybuild
+venv
+.venv

--- a/landscape/client/tests/test_watchdog.py
+++ b/landscape/client/tests/test_watchdog.py
@@ -1527,5 +1527,5 @@ class WatchDogRunTests(LandscapeTest):
         with mock.patch("landscape.client.watchdog.pwd", new=self.fake_pwd):
             run(["--log-dir", self.makeDir()], reactor=reactor)
 
-        mock_auto_configure.assert_called_once_with()
+        mock_auto_configure.assert_called_once_with(retry=True)
         self.assertTrue(reactor.running)

--- a/landscape/client/watchdog.py
+++ b/landscape/client/watchdog.py
@@ -721,7 +721,7 @@ def run(args=sys.argv, reactor=None):
     init_logging(config, "watchdog")
 
     if IS_SNAP:
-        config.auto_configure()
+        config.auto_configure(retry=True)
 
     application = Application("landscape-client")
     watchdog_service = WatchDogService(config)


### PR DESCRIPTION
This is a fix for an issue reported [here](https://forum.snapcraft.io/t/reboot-required-before-landscape-client-device-available-in-backend/41069).

When building a gadget snap and we configure auto-setting the computer title, it's not set until the landscape-client service is restarted. This occurs when we're waiting for the device's serial.

Given the following config in the `gadget.yaml`:

```yaml
defaults:
  # landscape client
  ffnH0sJpX3NFAclH777M8BdXIWpo93af:
    landscape-url: "https://landscape.stephenmwangi.com"
    account-name: "standalone"
    registration-key: "RegKey"
    log-level: debug
    auto-register:
      enabled: true
      computer-title-pattern: ${serial}
      wait-for-serial-as: true
```

<details>
<summary>Logs after starting the Ubuntu Core device - the process gets stuck here <i>(click collapsible)</i></summary>
  
```
2024-07-23 06:54:15,436 INFO     [MainThread] Registering plugin landscape.client.monitor.snapservicesmonitor.SnapServicesMonitor.
2024-07-23 06:54:15,444 DEBUG    [MainThread] delaying start of landscape.client.monitor.mountinfo.MountInfo for 13 seconds
2024-07-23 06:54:15,444 DEBUG    [MainThread] delaying start of landscape.client.monitor.usermonitor.UserMonitor for 93 seconds
2024-07-23 06:54:15,445 DEBUG    [MainThread] delaying start of landscape.client.monitor.rebootrequired.RebootRequired for 71 seco
nds
2024-07-23 06:54:15,445 DEBUG    [MainThread] delaying start of landscape.client.monitor.networkactivity.NetworkActivity for 0 se$
onds
2024-07-23 06:54:15,446 DEBUG    [MainThread] delaying start of landscape.client.monitor.swiftusage.SwiftUsage for 0 seconds
2024-07-23 06:54:20,684 INFO     [MainThread] This machine does not appear to be a Swift machine. Deactivating plugin.
2024-07-23 06:54:45,437 INFO     [MainThread] This machine does not appear to be a Ceph machine. Deactivating plugin.
2024-07-23 06:55:05,263 DEBUG    [MainThread] Started firing impending-exchange.
2024-07-23 06:55:05,264 DEBUG    [MainThread] Calling landscape.client.broker.server.event.<locals>.broadcast_event() for impendin
g-exchange with priority 0.
2024-07-23 06:55:05,267 DEBUG    [MainThread] Finished firing impending-exchange.
2024-07-23 06:55:05,269 DEBUG    [MainThread] Started firing impending-exchange.
2024-07-23 06:55:05,270 DEBUG    [MainThread] Calling landscape.client.broker.client.BrokerClient.notify_exchange() for impending-
exchange with priority 0.
2024-07-23 06:55:05,271 INFO     [MainThread] Got notification of impending exchange. Notifying all plugins.
2024-07-23 06:55:05,270 DEBUG    [MainThread] Started firing impending-exchange.
2024-07-23 06:55:05,271 DEBUG    [MainThread] Calling landscape.client.broker.client.BrokerClient.notify_exchange() for impending-
exchange with priority 0.
2024-07-23 06:55:05,272 INFO     [MainThread] Got notification of impending exchange. Notifying all plugins.
2024-07-23 06:55:05,275 DEBUG    [MainThread] Finished firing impending-exchange.
2024-07-23 06:55:05,289 DEBUG    [MainThread] Finished firing impending-exchange.
2024-07-23 06:55:15,262 DEBUG    [MainThread] Started firing pre-exchange.
2024-07-23 06:55:15,263 DEBUG    [MainThread] Calling landscape.client.broker.registration.RegistrationHandler._handle_pre_exchang
e() for pre-exchange with priority 0.
2024-07-23 06:55:15,264 DEBUG    [MainThread] Finished firing pre-exchange.
2024-07-23 06:55:15,265 INFO     [MainThread] Starting urgent message exchange with https://landscape.stephenmwangi.com/message-sy
stem.
2024-07-23 06:55:15,270 DEBUG    [PoolThread-twisted.internet.reactor-0] Sending payload:
{'accepted-types': b'\xd4\x1d\x8c\xd9\x8f\x00\xb2\x04\xe9\x80\t\x98\xec\xf8B~',
 'client-accepted-types': ['accepted-types',
                           'add-group',
                           'add-group-member',
                           'add-user',
                           'custom-graph-add',
                           'custom-graph-remove',
                           'edit-group',
                           'edit-user',
                           'execute-script',
                           'hold-snaps',
                           'install-snaps',
                           'lock-user',
                           'refresh-snaps',
                           'registration',
                           'remove-group',
                           'remove-group-member',
                           'remove-snaps',
                           'remove-user',
                           'restart-snap-service',
                           'restart-snap-service-batch',
                           'resynchronize',
                           'set-id',
                           'set-intervals',
                           'set-snap-config',
                           'shutdown',
                           'signal-process',
                           'start-snap-service',
                           'start-snap-service-batch',
                           'stop-snap-service',
                           'stop-snap-service-batch',
                           'unhold-snaps',
                           'unknown-id',
                           'unlock-user'],
 'client-api': b'3.8',
 'messages': [],
 'next-expected-sequence': 0,
 'sequence': 0,
 'server-api': b'3.2',
 'total-messages': 0}
2024-07-23 06:55:16,405 INFO     [PoolThread-twisted.internet.reactor-0] Sent 766 bytes and received 145 bytes in 1.14s.
2024-07-23 06:55:16,406 DEBUG    [PoolThread-twisted.internet.reactor-0] Received payload:
{'messages': [{'type': 'accepted-types', 'types': ['register', 'test']}],
 'server-api': '3.3',
 'server-uuid': b'7266d665-4820-11ef-9048-7259e5e54258'}
2024-07-23 06:55:16,411 INFO     [MainThread] Switching to normal exchange mode.
2024-07-23 06:55:16,412 INFO     [MainThread] Server UUID changed (old=None, new=7266d665-4820-11ef-9048-7259e5e54258).
2024-07-23 06:55:16,413 DEBUG    [MainThread] Started firing server-uuid-changed.
2024-07-23 06:55:16,413 DEBUG    [MainThread] Calling landscape.client.broker.server.event.<locals>.broadcast_event() for server-u
uid-changed with priority 0.
2024-07-23 06:55:16,415 DEBUG    [MainThread] Finished firing server-uuid-changed.
2024-07-23 06:55:16,417 DEBUG    [MainThread] Started firing message.
2024-07-23 06:55:16,417 DEBUG    [MainThread] Calling landscape.client.broker.ping.Pinger._handle_set_intervals() for message with
 priority 0.
2024-07-23 06:55:16,418 DEBUG    [MainThread] Calling landscape.client.broker.server.BrokerServer.broadcast_message() for message
with priority 0.
2024-07-23 06:55:16,419 DEBUG    [MainThread] Finished firing message.
2024-07-23 06:55:16,420 INFO     [MainThread] Accepted types changed: +register +test
2024-07-23 06:55:16,420 DEBUG    [MainThread] Started firing message-type-acceptance-changed.
2024-07-23 06:55:16,421 DEBUG    [MainThread] Calling landscape.client.broker.server.event.<locals>.broadcast_event() for message-
type-acceptance-changed with priority 0.
2024-07-23 06:55:16,422 DEBUG    [MainThread] Finished firing message-type-acceptance-changed.
2024-07-23 06:55:16,423 DEBUG    [MainThread] Started firing message-type-acceptance-changed.
2024-07-23 06:55:16,423 DEBUG    [MainThread] Calling landscape.client.broker.server.event.<locals>.broadcast_event() for message-
type-acceptance-changed with priority 0.
2024-07-23 06:55:16,425 DEBUG    [MainThread] Finished firing message-type-acceptance-changed.
2024-07-23 06:55:16,426 DEBUG    [MainThread] Started firing exchange-done.
```
</details>

<br/>

```console
$ cat /var/snap/landscape-client/common/etc/landscape-client.conf
[client]
account_name = standalone
computer_title =
url = https://landscape.stephenmwangi.com/message-system
ping_url = https://landscape.stephenmwangi.com/ping
log_level = debug
script_users = ALL
manager_plugins = ProcessKiller,UserManager,ShutdownManager,HardwareInfo,KeystoneToken,SnapManager,SnapServicesManager,ScriptExecution
monitor_plugins = ActiveProcessInfo,ComputerInfo,LoadAverage,MemoryInfo,MountInfo,ProcessorInfo,Temperature,UserMonitor,RebootRequired,NetworkActivity,NetworkDevice,CPUUsage,SwiftUsage,CephUsage,ComputerTags,SnapServicesMonitor
registration_key = RegKey
```

The computer title is set after restarting:
```console
$ snap restart landscape-client
Restarted.
$ cat /var/snap/landscape-client/common/etc/landscape-client.conf
[client]
account_name = standalone
computer_title = 9a36e630-a82c-44f9-b5b1-220eb4128d5f
url = https://landscape.stephenmwangi.com/message-system
ping_url = https://landscape.stephenmwangi.com/ping
log_level = debug
script_users = ALL
manager_plugins = ProcessKiller,UserManager,ShutdownManager,HardwareInfo,KeystoneToken,SnapManager,SnapServicesManager,ScriptExecution
monitor_plugins = ActiveProcessInfo,ComputerInfo,LoadAverage,MemoryInfo,MountInfo,ProcessorInfo,Temperature,UserMonitor,RebootRequired,NetworkActivity,NetworkDevice,CPUUsage,SwiftUsage,CephUsage,ComputerTags,SnapServicesMonitor
registration_key = Regkey
```

<details>
<summary>The device is now registered <i>(click collapsible)</i></summary>
<img src="https://github.com/user-attachments/assets/50c18041-2dba-4aae-a59d-a6a941c80a1c" />

</details>