### PR TITLE
fix: patch missing Trial addDuration method in py312

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYDOCTOR ?= pydoctor
 TXT2MAN ?= txt2man
 PYTHON ?= python3
 SNAPCRAFT = SNAPCRAFT_BUILD_INFO=1 snapcraft
-TRIAL ?= -m twisted.trial
+TRIAL ?= -m landscape.lib.run_tests
 TRIAL_ARGS ?=
 PRE_COMMIT ?= $(HOME)/.local/bin/pre-commit
 

--- a/landscape/lib/run_tests.py
+++ b/landscape/lib/run_tests.py
@@ -1,0 +1,14 @@
+if __name__ == "__main__":
+    # Patch Twisted Trial's `_AdaptedReporter` to add the Python 3.12-expected `addDuration` method.
+    # This eliminates a large amount of emitted warnings, and should no longer be necessary once
+    # https://github.com/twisted/twisted/issues/12229 is fixed.
+    import sys
+    from twisted.trial.reporter import _AdaptedReporter
+    from twisted.scripts.trial import run
+
+    def _addDuration(self, _test, _elapsed):
+        pass
+
+    _AdaptedReporter.addDuration = _addDuration
+
+    sys.exit(run())

--- a/landscape/lib/run_tests.py
+++ b/landscape/lib/run_tests.py
@@ -1,6 +1,7 @@
 if __name__ == "__main__":
-    # Patch Twisted Trial's `_AdaptedReporter` to add the Python 3.12-expected `addDuration` method.
-    # This eliminates a large amount of emitted warnings, and should no longer be necessary once
+    # Patch Twisted Trial's `_AdaptedReporter` to add the Python 3.12-expected
+    # `addDuration` method. This eliminates a large amount of emitted warnings,
+    # and should no longer be necessary once
     # https://github.com/twisted/twisted/issues/12229 is fixed.
     import sys
     from twisted.trial.reporter import _AdaptedReporter


### PR DESCRIPTION
Twisted Trial has a bug where the `_AdaptedReporter` is missing the `addDuration` method. A warning is emitted for this in Python 3.12. This patch adds a no-op one to eliminate these warnings. It can be removed once this is fixed in Twisted.