### PR TITLE
fix: ensure preferences.d directory exists in created APT dirs

### DIFF
--- a/landscape/lib/apt/package/facade.py
+++ b/landscape/lib/apt/package/facade.py
@@ -154,6 +154,7 @@ class AptFacade:
     def _ensure_dir_structure(self):
         apt_dir = self._ensure_sub_dir("etc/apt")
         self._ensure_sub_dir("etc/apt/sources.list.d")
+        self._ensure_sub_dir("etc/apt/preferences.d")
         self._ensure_sub_dir("var/cache/apt/archives/partial")
         self._ensure_sub_dir("var/lib/apt/lists/partial")
         dpkg_dir = self._ensure_sub_dir("var/lib/dpkg")


### PR DESCRIPTION
Ubuntu 24.04 and higher expect the `preferences.d` directory to exist in any directory being treated as an APT config directory. Creation of this directory was missing in `AptFacade`, which was leading to warnings when running some tests, such as `andscape.lib.apt.package.tests.test_facade.AptFacadeTest.test_custom_root_create_required_files`.