### PR TITLE
fix: add Date and hash fields to tests that create repositories

### DIFF
--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -1187,7 +1187,9 @@ class PackageReporterAptTest(LandscapeTest):
         release_path = os.path.join(self.repository_dir, "Release")
         with open(release_path, "w") as release:
             release.write(
-                "Suite: {}-security".format(os_release_info["code-name"]),
+                f"Suite: {os_release_info['code-name']}-security\n"
+                "Date: Sat, 02 Jul 2016 05:20:50 +0000\n"
+                "MD5Sum: deadbeef"
             )
 
         self.store.set_hash_ids({HASH1: 1, HASH2: 2, HASH3: 3})
@@ -1246,7 +1248,9 @@ class PackageReporterAptTest(LandscapeTest):
         release_path = os.path.join(self.repository_dir, "Release")
         with open(release_path, "w") as release:
             release.write(
-                "Suite: {}-backports".format(os_release_info["code-name"]),
+                f"Suite: {os_release_info['code-name']}-backports\n"
+                "Date: Sat, 02 Jul 2016 05:20:50 +0000\n"
+                "MD5Sum: deadbeef"
             )
 
         self.store.set_hash_ids({HASH1: 1, HASH2: 2, HASH3: 3})
@@ -1269,7 +1273,11 @@ class PackageReporterAptTest(LandscapeTest):
 
         release_path = os.path.join(self.repository_dir, "Release")
         with open(release_path, "w") as release:
-            release.write("Suite: my-personal-backports")
+            release.write(
+                "Suite: my-personal-backports"
+                "Date: Sat, 02 Jul 2016 05:20:50 +0000\n"
+                "MD5Sum: deadbeef"
+            )
 
         self.store.set_hash_ids({HASH1: 1, HASH2: 2, HASH3: 3})
 
@@ -1306,11 +1314,17 @@ class PackageReporterAptTest(LandscapeTest):
         official_release_path = os.path.join(self.repository_dir, "Release")
         with open(official_release_path, "w") as release:
             release.write(
-                "Suite: {}-backports".format(os_release_info["code-name"]),
+                f"Suite: {os_release_info['code-name']}-backports\n"
+                "Date: Sat, 02 Jul 2016 05:20:50 +0000\n"
+                "MD5Sum: deadbeef"
             )
         unofficial_release_path = os.path.join(other_backport_dir, "Release")
         with open(unofficial_release_path, "w") as release:
-            release.write("Suite: my-personal-backports")
+            release.write(
+                "Suite: my-personal-backports\n"
+                "Date: Sat, 02 Jul 2016 05:20:50 +0000\n"
+                "MD5Sum: deadbeef"
+            )
 
         self.store.set_hash_ids({HASH1: 1, HASH2: 2, HASH3: 3})
 


### PR DESCRIPTION
apt-cache expects all package repositories to have the `Date` field and some kind of hash (`MD5Sum`, `SHA1`, `SHA256`) field in their `Release` files. It will emit a warning it either of these are missing, which was polluting our test output. This patch adds these fields in tests to satisfy apt-cache.