### PR TITLE
fix: reduce computer title retry delay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-22.04", "ubuntu-20.04"]
+        os: ["ubuntu-22.04", "ubuntu-20.04", "ubuntu-24.04"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/landscape/client/deployment.py
+++ b/landscape/client/deployment.py
@@ -200,7 +200,7 @@ class Configuration(BaseConfiguration):
         backwards-compatibility."""
         return os.path.join(self.data_path, "juju-info.json")
 
-    def auto_configure(self, retry=False, delay=120, max_retries=5):
+    def auto_configure(self, retry=False, delay=15, max_retries=7):
         """Automatically configure the client snap."""
         client_conf = snap_http.get_conf("landscape-client").result
         auto_enroll_conf = client_conf.get("auto-register", {})
@@ -224,8 +224,10 @@ class Configuration(BaseConfiguration):
             if not retry:
                 break
 
-            # retry until we get the computer title (exponential backoff)
-            # number of retries capped by `max_retries`
+            # Retry until we get the computer title (with exponential backoff)
+            # The number of retries is capped by `max_retries`
+            # With the defaults (delay=15s, max_retries=7), we'll
+            # retry over a period of ~30 minutes.
             time.sleep(delay)
             delay *= 2
 


### PR DESCRIPTION
Got feedback [here](https://forum.snapcraft.io/t/reboot-required-before-landscape-client-device-available-in-backend/41069/11) to reduce the delay between retries. The initial 2 minutes was a little too long.. Now we'll retry after 15s, then 30, 60, etc over a span of ~30 minutes.