### PR TITLE
fix: get ubuntu pro info on snaps

### DIFF
--- a/landscape/client/__init__.py
+++ b/landscape/client/__init__.py
@@ -9,3 +9,9 @@ GROUP = "root" if IS_SNAP else "landscape"
 DEFAULT_CONFIG = (
     "/etc/landscape-client.conf" if IS_SNAP else "/etc/landscape/client.conf"
 )
+
+UA_DATA_DIR = (
+    "/var/lib/snapd/hostfs/var/lib/ubuntu-advantage"
+    if IS_SNAP
+    else "/var/lib/ubuntu-advantage"
+)

--- a/landscape/client/manager/ubuntuproinfo.py
+++ b/landscape/client/manager/ubuntuproinfo.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from landscape.client import IS_CORE
 from landscape.client import IS_SNAP
+from landscape.client import UA_DATA_DIR
 from landscape.client.manager.plugin import ManagerPlugin
 from landscape.lib.persist import Persist
 
@@ -80,9 +81,47 @@ def get_ubuntu_pro_info() -> dict:
         )
 
     if IS_SNAP:
-        # Snap does not support Ubuntu Pro Info and throws an error if `pro` is
-        # called.
-        return {}
+        # By default, Ubuntu Advantage / Pro stores the status information
+        # in /var/lib/ubuntu-advantage/status.json (we have a `system-files`
+        # plug for this).
+        # This `data_dir` can however be changed in
+        # /etc/ubuntu-advantage/uaclient.conf which would lead to
+        # permission errors since we don't have a plug for arbitrary
+        # folders on the host fs.
+
+        try:
+            with open(f"{UA_DATA_DIR}/status.json") as fp:
+                pro_info = json.load(fp)
+        except (FileNotFoundError, PermissionError):
+            # Happens if the Ubuntu Pro client isn't installed, or
+            #  if the `data_dir` folder setting was changed from the default
+            return {}
+
+        # The status file has more information than `pro status`
+        keys_to_keep = [
+            "_doc",
+            "_schema_version",
+            "account",
+            "attached",
+            "config",
+            "config_path",
+            "contract",
+            "effective",
+            "environment_vars",
+            "errors",
+            "execution_details",
+            "execution_status",
+            "expires",
+            "features",
+            "machine_id",
+            "notices",
+            "result",
+            "services",
+            "simulated",
+            "version",
+            "warnings",
+        ]
+        return {k: pro_info[k] for k in keys_to_keep if k in pro_info}
 
     try:
         completed_process = subprocess.run(

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,12 @@ environment:
   LANDSCAPE_CLIENT_SNAP: 1
   PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.10/site-packages:$PYTHONPATH
 
+plugs:
+  var-lib-ubuntu-advantage-status:
+    interface: system-files
+    read:
+      - /var/lib/snapd/hostfs/var/lib/ubuntu-advantage/status.json
+
 apps:
   landscape-client:
     daemon: simple
@@ -42,6 +48,7 @@ apps:
       - process-control
       - network-control
       - network-manager
+      - var-lib-ubuntu-advantage-status
   config:
     command: usr/bin/landscape-config
     plugs: [network]


### PR DESCRIPTION
[The Bug Report](https://bugs.launchpad.net/landscape-client/+bug/2074026)

This fix will allow the snap to push Ubuntu Pro information to Landscape by reading the `/var/lib/ubuntu-advantage/status.json` file. We have a `system-files` plug for this file.

One caveat is that the `data_dir` setting (`/var/lib/ubuntu-advantage/`) can be changed in `/etc/ubuntu-advantage/uaclient.conf` which would prevent the snap from reading the status file, as we can't plug into arbitrary folders on the host fs, especially not at runtime.

<details>
<summary>Sample Output (click to expand)</summary>

![image](https://github.com/user-attachments/assets/9ac68b65-0661-4ef0-af5b-deea102ab558)

</details>