### PR TITLE
build: use dev-lxc to fully configure container

### DIFF
--- a/.dev-lxc/config.yaml
+++ b/.dev-lxc/config.yaml
@@ -1,0 +1,11 @@
+config:
+  user.user-data: |
+    #cloud-config
+    package_upgrade: true
+    packages:
+      - make
+    runcmd:
+      - usermod -a -G ubuntu landscape
+dev-lxc-exec:
+  - make depends
+  - git submodule update --init


### PR DESCRIPTION
The configuration of the container for Landscape client would use `dev-lxc` to set up the container, but would then require the user to run a few more manual steps. Here, those additional manual steps are now done automatically. The command should be run as:
```
dev_lxc create --config ./.dev-lxc/config.yaml jammy
```

