### PR TITLE
fix: parse livepatch process status check

### DIFF
--- a/landscape/client/manager/livepatch.py
+++ b/landscape/client/manager/livepatch.py
@@ -29,15 +29,15 @@ class LivePatch(DataWatcherManager):
 
 
 def _parse_humane(output):
-    entries = output.split("\n")
+    entries = output.splitlines()
     data = {}
 
-    for e in entries:
-        line = e.strip()
-        if len(line) == 0:
+    for entry in entries:
+        line = entry.strip()
+        if line == "":
             continue
-        elif ": " in line:
-            key, value = line.split(": ", 1)
+        elif ":" in line:
+            key, value = line.split(":", 1)
             key = key.strip().strip('"').strip("'")
             value = value.strip().strip('"').strip("'")
             data[key] = value

--- a/landscape/client/manager/livepatch.py
+++ b/landscape/client/manager/livepatch.py
@@ -2,8 +2,6 @@ import json
 import logging
 import subprocess
 import traceback
-import yaml
-
 
 from landscape.client.manager.plugin import DataWatcherManager
 
@@ -22,10 +20,22 @@ class LivePatch(DataWatcherManager):
     run_interval = 1800  # Every 30 min
 
     def get_data(self):
-        json_output = get_livepatch_status('json')
-        readable_output = get_livepatch_status('humane')
-        return json.dumps({'humane': readable_output, 'json': json_output},
-                          sort_keys=True)  # Prevent randomness for cache
+        json_output = get_livepatch_status("json")
+        readable_output = get_livepatch_status("humane")
+        return json.dumps(
+            {"humane": readable_output, "json": json_output}, sort_keys=True
+        )  # Prevent randomness for cache
+
+
+def _parse_humane(cmd_output):
+    entries = cmd_output.split("\n")
+    data = {}
+
+    for e in entries:
+        key, value = e.split(":", 1)
+        data[key] = value.strip()
+
+    return data
 
 
 def get_livepatch_status(format_type):
@@ -40,36 +50,47 @@ def get_livepatch_status(format_type):
     try:
         completed_process = subprocess.run(
             ["canonical-livepatch", "status", "--format", format_type],
-            encoding="utf8", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            encoding="utf8",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
     except FileNotFoundError as exc:
-        data['return_code'] = -1
-        data['error'] = str(exc)
-        data['output'] = ""
+        data["return_code"] = -1
+        data["error"] = str(exc)
+        data["output"] = ""
     except Exception as exc:
-        data['return_code'] = -2
-        data['error'] = str(exc)
-        data['output'] = ""
+        data["return_code"] = -2
+        data["error"] = str(exc)
+        data["output"] = ""
         logging.error(traceback.format_exc())
     else:
         output = completed_process.stdout.strip()
         try:
             if output:  # We don't want to parse an empty string
-                if format_type == 'json':
+                if format_type == "json":
                     output = json.loads(output)
-                    if 'Last-Check' in output:  # Remove timestamps for cache
-                        del output['Last-Check']
-                    if 'Uptime' in output:
-                        del output['Uptime']
+                    if "Last-Check" in output:  # Remove timestamps for cache
+                        del output["Last-Check"]
+                    if "Uptime" in output:
+                        del output["Uptime"]
                 else:
-                    output = yaml.safe_load(output)
-                    if 'last check' in output:
-                        del output['last check']
-            data['return_code'] = completed_process.returncode
-            data['error'] = completed_process.stderr
-            data['output'] = output
-        except (yaml.YAMLError, json.decoder.JSONDecodeError) as exc:
-            data['return_code'] = completed_process.returncode
-            data['error'] = str(exc)
-            data['output'] = output
+                    output = _parse_humane(output)
+                    if "last check" in output:
+                        del output["last check"]
+            data["return_code"] = completed_process.returncode
+            data["error"] = err or completed_process.stderr
+            data["output"] = output
+        except json.decoder.JSONDecodeError as exc:
+            data["return_code"] = completed_process.returncode
+            data["error"] = str(exc)
+            data["output"] = output
+
+            # "last check: 16 seconds ago\n
+            # kernel: 6.8.0-41.41-generic\n
+            # server check-in: failed: livepatch check failed: POST request to \"https://livepatch.canonical.com/v1/client/e93452b8cff04bb8a6320ad7dae797e5/updates\" failed\n
+            # kernel state: ✓ kernel series 6.8 is covered by Livepatch\n
+            # patch state: ✓ no livepatches available for kernel 6.8.0-41.41-generic\n
+            # tier: updates (Free usage; This machine beta tests new patches.)\n
+            # machine id: e93452b8cff04bb8a6320ad7dae797e5",
 
     return data

--- a/landscape/client/manager/livepatch.py
+++ b/landscape/client/manager/livepatch.py
@@ -37,11 +37,11 @@ def _preparse_humane(output):
             key, value = e.split(": ", 1)
             key = key.strip()
             value = value.strip()
-            data.append(f"{key}: {value}\n")
+            data.append(f"'{key}': '{value}'")
         else:
-            data.append(e.strip() + "\n")
+            data.append(e.strip())
 
-    data = "".join(data)
+    data = "\n".join(data)
 
     return data
 

--- a/landscape/client/manager/livepatch.py
+++ b/landscape/client/manager/livepatch.py
@@ -42,7 +42,9 @@ def _parse_humane(output):
             value = value.strip().strip('"').strip("'")
             data[key] = value
         else:
-            raise yaml.YAMLError("Input is not a list of key/value pairs")
+            raise yaml.YAMLError(
+                "Input is not a list of key/value pairs: " + output
+            )
 
     return data
 

--- a/landscape/client/manager/tests/test_livepatch.py
+++ b/landscape/client/manager/tests/test_livepatch.py
@@ -109,8 +109,6 @@ class LivePatchTest(LandscapeTest):
         with default yaml. Ensure that outputs similar to "server check-in:
         failed: fail message" will be parsed without a parser error.
         """
-        plugin = LivePatch()
-
         fail_key = "fail message"
         fail_value = "may have: multiple: colons"
         fail_message_data = f"{fail_key}: {fail_value}"


### PR DESCRIPTION
The LivePatch plugin runs `canonical-livepatch status --format humane` to get kernel information. 
```
$ canonical-livepatch status --format humane
last check: 54 minutes ago
kernel: 6.8.0-40.40-generic
server check-in: succeeded
kernel state: ✓ kernel series 6.8 is covered by Livepatch
patch state: ✓ no livepatches available for kernel 6.8.0-40.40-generic
tier: updates (Free usage; This machine beta tests new patches.)
machine id: asdfsasdfasdfasdf
```

However, if this command fails, we could not parse that output to still receive other information, and would result in a yaml parser error.
```
$ canonical-livepatch status --format humane
last check: 50 minutes ago
kernel: 6.8.0-41.41-generic
server check-in: failed: livepatch check failed: POST request to "badurl.com/v1/client/asdfsasdfasdfasdf/updates" failed
kernel state: ✓ kernel series 6.8 is covered by Livepatch
patch state: ✓ no livepatches available for kernel 6.8.0-41.41-generic
tier: updates (Free usage; This machine beta tests new patches.)
machine id: asdfsasdfasdfasdf
```
Note that due to additional colons in the "server check-in" entry, yaml.safe_load would not be able to parse this output.

This fix is a custom parser to read the entries in place of yaml.safe_load to handle if the livepatch status command fails.

Manual Test:
1. Start server instance with freshdata
2. Edit client's .conf file to connect to server
3. Register a dev client with the livepatch plugin (enabled by default)
4. [Install](https://linuxhandbook.com/livepatch-ubuntu-server/) and [enable](https://auth.livepatch.canonical.com/) livepatch in the dev environment
5. `sudo canonical-livepatch config remote-server="badurl.com"`
6. `sudo ./scripts/landscape-client`
7. Get JWT token
8. `http GET "http://<server ip>:9091/api/v2/computers/<computer id>"  Authorization:"Bearer $JWT"`
9. Find the livepatch information and check to see that server check-in contains a failure message

Reference:
```
$ JWT=$(curl -X POST "http://<server ip>:8080/api/v2/login" -d '{"email": "john@example.com", "password": "pwd"}' | grep '"token": "[^"]*"' | awk -F'"token": "' '{print $2}' | awk -F'"' '{print $1}')
$ http GET "http://<server ip>:9091/api/v2/computers/<computer id>"  Authorization:"Bearer $JWT" | jq ".livepatch_info"
```

