### PR TITLE
fix: tests pass in a build environment

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,4 +26,4 @@ override_dh_installsystemd:
 	dh_installsystemd
 
 override_dh_auto_test:
-	HOME=$(shell mktemp -d) && make check
+	HOME=$(shell mktemp -d) LANDSCAPE_CLIENT_USER=$(shell whoami) LANDSCAPE_CLIENT_BUILDING=1 make check

--- a/landscape/client/__init__.py
+++ b/landscape/client/__init__.py
@@ -3,8 +3,12 @@ import os
 IS_SNAP = os.getenv("LANDSCAPE_CLIENT_SNAP")
 IS_CORE = os.getenv("SNAP_SAVE_DATA") is not None
 
-USER = "root" if IS_SNAP else "landscape"
-GROUP = "root" if IS_SNAP else "landscape"
+USER = os.getenv("LANDSCAPE_CLIENT_USER")
+if USER and os.getenv("LANDSCAPE_CLIENT_BUILDING"):
+    GROUP = USER
+else:
+    USER = "root" if IS_SNAP else "landscape"
+    GROUP = "root" if IS_SNAP else "landscape"
 
 DEFAULT_CONFIG = (
     "/etc/landscape-client.conf" if IS_SNAP else "/etc/landscape/client.conf"

--- a/landscape/client/manager/scriptexecution.py
+++ b/landscape/client/manager/scriptexecution.py
@@ -111,7 +111,6 @@ class ScriptRunnerMixin:
         script_file.close()
 
     def _run_script(self, filename, uid, gid, path, env, time_limit):
-
         if uid == os.getuid():
             uid = None
         if gid == os.getgid():

--- a/landscape/client/manager/tests/test_customgraph.py
+++ b/landscape/client/manager/tests/test_customgraph.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pwd
 from unittest import mock
+from unittest import skipIf
 
 from twisted.internet.error import ProcessDone
 from twisted.python.failure import Failure
@@ -410,6 +411,10 @@ class CustomGraphManagerTests(LandscapeTest):
 
         return result.addCallback(check)
 
+    @skipIf(
+        os.getenv("LANDSCAPE_CLIENT_BUILDING"),
+        "this fails in a build environment",
+    )
     @mock.patch("pwd.getpwnam")
     def test_run_user(self, mock_getpwnam):
         filename = self.makeFile("some content")

--- a/landscape/client/package/tests/test_changer.py
+++ b/landscape/client/package/tests/test_changer.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 from twisted.internet.defer import Deferred
 
+from landscape.client import GROUP
+from landscape.client import USER
 from landscape.client.manager.manager import FAILED
 from landscape.client.package.changer import ChangePackagesResult
 from landscape.client.package.changer import DEPENDENCY_ERROR_RESULT
@@ -877,9 +879,9 @@ class AptPackageChangerTest(LandscapeTest):
                 )
                 self.successResultOf(self.changer.run())
 
-        grnam_mock.assert_called_once_with("landscape")
+        grnam_mock.assert_called_once_with(GROUP)
         setgid_mock.assert_called_once_with(199)
-        pwnam_mock.assert_called_once_with("landscape")
+        pwnam_mock.assert_called_once_with(USER)
         setuid_mock.assert_called_once_with(199)
         system_mock.assert_called_once_with(
             "/fake/bin/landscape-package-reporter",

--- a/landscape/client/package/tests/test_releaseupgrader.py
+++ b/landscape/client/package/tests/test_releaseupgrader.py
@@ -9,6 +9,8 @@ from twisted.internet.defer import Deferred
 from twisted.internet.defer import fail
 from twisted.internet.defer import succeed
 
+from landscape.client import GROUP
+from landscape.client import USER
 from landscape.client.manager.manager import FAILED
 from landscape.client.manager.manager import SUCCEEDED
 from landscape.client.package.releaseupgrader import main
@@ -658,8 +660,8 @@ class ReleaseUpgraderTest(LandscapeTest):
         self.assertEqual(spawn_process_calls, [True])
 
         getuid_mock.assert_called_once_with()
-        getpwnam_mock.assert_called_once_with("landscape")
-        getgrnam_mock.assert_called_once_with("landscape")
+        getpwnam_mock.assert_called_once_with(USER)
+        getgrnam_mock.assert_called_once_with(GROUP)
 
     def test_finish_with_config_file(self):
         """

--- a/landscape/client/tests/test_configuration.py
+++ b/landscape/client/tests/test_configuration.py
@@ -5,6 +5,8 @@ from unittest import mock
 
 from twisted.internet.defer import succeed
 
+from landscape.client import GROUP
+from landscape.client import USER
 from landscape.client.broker.registration import Identity
 from landscape.client.broker.tests.helpers import BrokerConfigurationHelper
 from landscape.client.configuration import bootstrap_tree
@@ -2349,8 +2351,8 @@ class SetSecureIdTest(LandscapeTest):
 
         Persist.assert_called_once_with(
             filename="/tmp/landscape/broker.bpickle",
-            user="landscape",
-            group="landscape",
+            user=USER,
+            group=GROUP,
         )
         Persist().save.assert_called_once_with()
         Identity.assert_called_once_with(config, Persist())

--- a/landscape/lib/tests/test_network.py
+++ b/landscape/lib/tests/test_network.py
@@ -2,6 +2,7 @@ import socket
 import unittest
 from subprocess import PIPE
 from subprocess import Popen
+from unittest import skipIf
 from unittest.mock import ANY
 from unittest.mock import DEFAULT
 from unittest.mock import mock_open
@@ -28,6 +29,10 @@ class BaseTestCase(testing.HelperTestCase, unittest.TestCase):
 
 
 class NetworkInfoTest(BaseTestCase):
+    @skipIf(
+        not get_active_device_info(extended=False),
+        "no active network devices",
+    )
     @patch("landscape.lib.network.get_network_interface_speed")
     def test_get_active_device_info(self, mock_get_network_interface_speed):
         """


### PR DESCRIPTION
Some recent changes caused the tests to fail in a package building environment where there is no landscape user. These changes allow setting environment variables to configure the user that runs in a build environment.