### PR TITLE
Add annotations content interface to snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,12 @@ plugs:
     read:
       - /var/lib/snapd/hostfs/var/lib/ubuntu-advantage/status.json
 
+slots:
+  annotations:
+    interface: content
+    write:
+      - $SNAP_DATA/var/lib/landscape/client/annotations.d
+
 apps:
   landscape-client:
     daemon: simple


### PR DESCRIPTION
Added a content interface to snapcraft.yaml to allow another snap to access the annotations directory.