### PR TITLE
fix: prevent creation of clones after reverting to previous snap revision

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -36,7 +36,6 @@ config_entries = [
     ("flush-interval", "flush_interval", None),
     ("exchange-interval", "exchange_interval", None),
     ("apt-update-interval", "apt_update_interval", None),
-    ("exchange-interval", "exchange_interval", None),
     ("cloud", "cloud", None),
 ]
 
@@ -44,7 +43,7 @@ changed = set()
 for snapctl_key, landscape_key, mapping_fn in config_entries:
     value = _snapctl("get", snapctl_key).strip()
     if not value:
-        # empty, value not has not changed
+        # empty, value has not changed
         continue
 
     if mapping_fn:

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,26 @@
+#!/bin/sh -e
+
+# This hook migrates the client's data from $SNAP_DATA to $SNAP_COMMON.
+# It will be kept until all the existing
+#  clients are migrated to $SNAP_COMMON (using this hook).
+# Full bug report: https://bugs.launchpad.net/landscape-client/+bug/2082616
+
+OLD_DIR="$SNAP_DATA/var/lib/landscape/client"
+NEW_DIR="$SNAP_COMMON/var/lib/landscape/client"
+
+# Is a migration needed? We check if:
+#  1. $OLD_DIR exists
+#  2. And that we've not already done the migration
+if [ -d "$OLD_DIR" ] && [ ! -f "$NEW_DIR/.migrated" ]; then
+   # Copy files while preserving attributes, links, etc
+   cp -a "$OLD_DIR/." "$NEW_DIR/"
+
+   # Flush file system buffers, ensuring all pending writes are completed
+   sync
+
+   # Add migration completion marker
+   touch "$NEW_DIR/.migrated"
+
+   # Remove the old directory
+   rm -rf "$OLD_DIR"
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   in a Landscape account. It provides the Landscape client and requires a
   Landscape account.
 
-grade: stable # must be 'stable' to release into candidate/stable channels
+grade: stable
 architectures:
   - build-on: [amd64]
   - build-on: [arm64]
@@ -33,7 +33,7 @@ slots:
   annotations:
     interface: content
     write:
-      - $SNAP_DATA/var/lib/landscape/client/annotations.d
+      - $SNAP_COMMON/var/lib/landscape/client/annotations.d
 
 apps:
   landscape-client:
@@ -61,11 +61,21 @@ apps:
     plugs:
       - network
       - hardware-observe
+
+# Previously, the client's data was stored in $SNAP_DATA
+#  which led to duplicate machine entries after reverting
+#  to a previous revision.
+# After the migration of /var/lib/landscape/client from
+#  $SNAP_DATA to $SNAP_COMMON, the snap's layout changed.
+# The new epoch 1* means the snap can read the previous
+#  & new epochs' data but can only write epoch 1 data.
+epoch: 1*
+
 layout:
   /etc/landscape-client.conf:
     bind-file: $SNAP_COMMON/etc/landscape-client.conf
   /var/lib/landscape/client:
-    bind: $SNAP_DATA/var/lib/landscape/client
+    bind: $SNAP_COMMON/var/lib/landscape/client
   /var/log/landscape:
     bind: $SNAP_DATA/var/log/landscape
 


### PR DESCRIPTION
Reverting to a previous snap revision leads to duplicate machine entries because the snap's data is stored in `$SNAP_DATA` and not `$SNAP_COMMON`. When the data is stored in `$SNAP_DATA`, the snap starts seeing the old data from the previous revision of the snap. Since the state (message id, etc) doesn't match the one tracked by the server, a re-registration is requested leading to clones.

The full bug report is available on [Launchpad](https://bugs.launchpad.net/landscape-client/+bug/2082616).

How to reproduce
---

1. Install landscape-client from the `stable` channel & register:

```console
$ snap install landscape-client
$ snap set landscape-client log-level="debug"
$ snap set landscape-client exchange-interval=300
$ sudo landscape-client.config ...
[...]
Registration request sent successfully.
```

2. Wait until the first full message exchange takes place i.e. the computer's info like Distribution, Hardware, etc are populated on Landscape.

3. Refresh to the distribution from the `edge` channel.

```console
$ snap refresh landscape-client --edge
```

4. Wait until a message exchange takes place i.e. the computer's Last ping time is after the refresh. Then we'll revert back to the previous revision from `stable`:

```console
$ snap revert landscape-client
landscape-client reverted to 24.08
```

5. A clone should now appear on Landscape.

Checking the snap's folders, you'll notice that they've diverged (revision `244` is `stable` & `299` is `edge`). We moved from `244` -> `299` -> `244` but `244` still has files that are behind e.g.  `broker.bpickle`, `monitor.bpickle`.

```console
$ ls -la /var/snap/landscape-client/*/var/lib/landscape/client/
/var/snap/landscape-client/244/var/lib/landscape/client/:
total 88
drwxr-xr-x 7 root root  4096 Oct  7 12:39 .
drwxr-xr-x 3 root root  4096 Oct  7 12:35 ..
drwxr-xr-x 2 root root  4096 Oct  7 12:35 annotations.d
-rw-r--r-- 1 root root  1730 Oct  7 12:38 broker.bpickle
-rw-r--r-- 1 root root  1689 Oct  7 12:38 broker.bpickle.old
drwxr-xr-x 2 root root  4096 Oct  7 12:35 custom-graph-scripts
-rw-r--r-- 1 root root 12288 Oct  7 12:35 manager.database
drwxr-xr-x 3 root root  4096 Oct  7 12:35 messages
-rw-r--r-- 1 root root 17254 Oct  7 12:39 monitor.bpickle
-rw-r--r-- 1 root root 17247 Oct  7 12:37 monitor.bpickle.old
drwxr-xr-x 5 root root  4096 Oct  7 12:35 package
drwxr-x--- 2 root root  4096 Oct  7 12:39 sockets

/var/snap/landscape-client/299/var/lib/landscape/client/:
total 88
drwxr-xr-x 7 root root  4096 Oct  7 12:44 .
drwxr-xr-x 3 root root  4096 Oct  7 12:35 ..
drwxr-xr-x 2 root root  4096 Oct  7 12:35 annotations.d
-rw-r--r-- 1 root root  1651 Oct  7 12:42 broker.bpickle
-rw-r--r-- 1 root root  1651 Oct  7 12:41 broker.bpickle.old
drwxr-xr-x 2 root root  4096 Oct  7 12:35 custom-graph-scripts
-rw-r--r-- 1 root root 12288 Oct  7 12:35 manager.database
drwxr-xr-x 3 root root  4096 Oct  7 12:35 messages
-rw-r--r-- 1 root root 17242 Oct  7 12:44 monitor.bpickle
-rw-r--r-- 1 root root 17235 Oct  7 12:42 monitor.bpickle.old
drwxr-xr-x 5 root root  4096 Oct  7 12:35 package
drwxr-x--- 2 root root  4096 Oct  7 12:44 sockets

/var/snap/landscape-client/current/var/lib/landscape/client/:
total 88
drwxr-xr-x 7 root root  4096 Oct  7 12:39 .
drwxr-xr-x 3 root root  4096 Oct  7 12:35 ..
drwxr-xr-x 2 root root  4096 Oct  7 12:35 annotations.d
-rw-r--r-- 1 root root  1730 Oct  7 12:38 broker.bpickle
-rw-r--r-- 1 root root  1689 Oct  7 12:38 broker.bpickle.old
drwxr-xr-x 2 root root  4096 Oct  7 12:35 custom-graph-scripts
-rw-r--r-- 1 root root 12288 Oct  7 12:35 manager.database
drwxr-xr-x 3 root root  4096 Oct  7 12:35 messages
-rw-r--r-- 1 root root 17254 Oct  7 12:39 monitor.bpickle
-rw-r--r-- 1 root root 17247 Oct  7 12:37 monitor.bpickle.old
drwxr-xr-x 5 root root  4096 Oct  7 12:35 package
drwxr-x--- 2 root root  4096 Oct  7 12:39 sockets
```

Fix
---

We'll move the snap's data from the versioned `$SNAP_DATA` to `$SNAP_COMMON` which doesn't change across snap revisions. We need to migrate the existing data using a `post-refresh` hook & remove `$SNAP_DATA/var/lib/landscape/client` from the current revision.

To check if the migration works:

1. Remove `landscape-client` if it's still installed (we need to start on a blank slate) & repeat steps 1 & 2 from the _How to reproduce_ section above. Please register the computer with a different computer title.

2. Build the snap & install it:

```console
$ snapcraft
Generated snap metadata
Created snap package landscape-client_24.08_amd64.snap
$ snap install landscape-client_24.08_amd64.snap --dangerous
landscape-client 24.08 installed
```

3. Checking the new directory structure:

```console
$ ls -la /var/snap/landscape-client/*/var/lib/landscape/client/
/var/snap/landscape-client/244/var/lib/landscape/client/:
total 104
drwxr-xr-x 7 root root  4096 Oct  8 14:11 .
drwxr-xr-x 3 root root  4096 Oct  8 13:55 ..
drwxr-xr-x 2 root root  4096 Oct  8 14:01 annotations.d
-rw-r--r-- 1 root root  1730 Oct  8 14:04 broker.bpickle
-rw-r--r-- 1 root root  1689 Oct  8 14:04 broker.bpickle.old
drwxr-xr-x 2 root root  4096 Oct  8 14:01 custom-graph-scripts
-rw-r--r-- 1 root root     2 Oct  8 14:06 keystone.bpickle
-rw-r--r-- 1 root root 12288 Oct  8 14:01 manager.database
drwxr-xr-x 3 root root  4096 Oct  8 14:01 messages
-rw-r--r-- 1 root root 30199 Oct  8 14:11 monitor.bpickle
-rw-r--r-- 1 root root 17605 Oct  8 14:06 monitor.bpickle.old
drwxr-xr-x 5 root root  4096 Oct  8 14:01 package
drwxr-x--- 2 root root  4096 Oct  8 14:11 sockets

/var/snap/landscape-client/common/var/lib/landscape/client/:
total 200
drwxr-xr-x 7 root root  4096 Oct  8 14:23 .
drwxr-xr-x 3 root root  4096 Oct  8 14:11 ..
-rw-r--r-- 1 root root     0 Oct  8 14:11 .migrated
drwxr-xr-x 2 root root  4096 Oct  8 14:01 annotations.d
-rw-r--r-- 1 root root  1652 Oct  8 14:23 broker.bpickle
-rw-r--r-- 1 root root  1652 Oct  8 14:23 broker.bpickle.old
drwxr-xr-x 2 root root  4096 Oct  8 14:01 custom-graph-scripts
-rw-r--r-- 1 root root     2 Oct  8 14:21 keystone.bpickle
-rw-r--r-- 1 root root     2 Oct  8 14:16 keystone.bpickle.old
-rw-r--r-- 1 root root 12288 Oct  8 14:01 manager.database
drwxr-xr-x 3 root root  4096 Oct  8 14:01 messages
-rw-r--r-- 1 root root 70119 Oct  8 14:22 monitor.bpickle
-rw-r--r-- 1 root root 70119 Oct  8 14:22 monitor.bpickle.old
drwxr-xr-x 5 root root  4096 Oct  8 14:01 package
drwxr-x--- 2 root root  4096 Oct  8 14:11 sockets
```

Moving forward, the snaps will use `$SNAP_COMMON`.