### PR TITLE
fix: registration with landscape-client.config on the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,7 +58,9 @@ apps:
       - var-lib-ubuntu-advantage-status
   config:
     command: usr/bin/landscape-config
-    plugs: [network]
+    plugs:
+      - network
+      - hardware-observe
 layout:
   /etc/landscape-client.conf:
     bind-file: $SNAP_COMMON/etc/landscape-client.conf


### PR DESCRIPTION
After the [landscape-config refactor](https://github.com/canonical/landscape-client/pull/262/files), registering on new revisions of the snap fails since the `config` app cannot read files in `/sys/bus/xen/devices` & `/sys/class/dmi/id`.

To reproduce:

- `snap install landscape-client --edge`
- `sudo landscape-client.config ...` fails with the following error:

```
Traceback (most recent call last):
  File "/snap/landscape-client/294/usr/bin/landscape-config", line 16, in <module>
    main(sys.argv[1:])
  File "/snap/landscape-client/294/usr/lib/python3.10/site-packages/landscape/client/configuration.py", line 914, in main
    exit_code = attempt_registration(identity, config)
  File "/snap/landscape-client/294/usr/lib/python3.10/site-packages/landscape/client/configuration.py", line 739, in attempt_registration
    client_info = ClientRegistrationInfo.from_identity(identity)
  File "/snap/landscape-client/294/usr/lib/python3.10/site-packages/landscape/client/registration.py", line 61, in from_identity
    vm_info=get_vm_info(),
  File "/snap/landscape-client/294/usr/lib/python3.10/site-packages/landscape/lib/vm_info.py", line 23, in get_vm_info
    if _is_vm_xen(root_path):
  File "/snap/landscape-client/294/usr/lib/python3.10/site-packages/landscape/lib/vm_info.py", line 56, in _is_vm_xen
    return os.path.isdir(sys_xen_path) and os.listdir(sys_xen_path)
PermissionError: [Errno 13] Permission denied: '/sys/bus/xen/devices'
```

---

Fix:

Added the `hardware-observe` interface to the `landscape-client.config` app which gives it access to the necessary folders.

The [`hardware-observe` ](https://snapcraft.io/docs/hardware-observe-interface) interface will grant read access to these paths:
> - For tools like lspci -A linux-sysfs to get information on files in /sys:
> /sys/{block,bus,class,devices,firmware}/{,**}
> - For container information:
> /run/systemd/container

The `landscape-client` app is already connected to `hardware-observe` so no more auto-connection requests are required.