### PR TITLE
fix: process full server response

### DIFF
--- a/landscape/client/broker/tests/test_transport.py
+++ b/landscape/client/broker/tests/test_transport.py
@@ -66,7 +66,7 @@ class HTTPTransportTest(LandscapeTest):
             transport.exchange,
             payload,
             computer_id="34",
-            exchange_token="abcd-efgh",
+            exchange_token=b"abcd-efgh",
             message_api=b"X.Y",
         )
 

--- a/landscape/client/broker/transport.py
+++ b/landscape/client/broker/transport.py
@@ -33,7 +33,7 @@ class HTTPTransport:
         self,
         payload: dict,
         computer_id: Optional[str] = None,
-        exchange_token: Optional[str] = None,
+        exchange_token: Optional[bytes] = None,
         message_api: bytes = SERVER_API,
     ) -> Union[dict, None]:
         """Exchange message data with the server.
@@ -59,7 +59,16 @@ class HTTPTransport:
         except Exception:
             return None
 
-        return asdict(response)
+        # Return `ServerResponse` as a dictionary
+        #  converting the field names back to kebab case
+        #  which (imo) is better than mixing snake_case & kebab-case
+        #  in landscape.client.broker.exchange.MessageExchange.
+        return asdict(
+            response,
+            dict_factory=lambda data: {
+                k.replace("_", "-"): v for k, v in data
+            },
+        )
 
 
 class FakeTransport:

--- a/landscape/client/tests/test_exchange.py
+++ b/landscape/client/tests/test_exchange.py
@@ -29,7 +29,8 @@ class ExchangeMessagesTestCase(TestCase):
         payload = {"messages": [{"type": "my-message-type", "some-value": 5}]}
 
         mock_response = {
-            "server-uuid": "my-server-uuid",
+            "server-api": "3.2",
+            "server-uuid": b"my-server-uuid",
             "messages": [{"type": "my-server-message-type", "other-value": 6}]
         }
 
@@ -40,10 +41,11 @@ class ExchangeMessagesTestCase(TestCase):
             "https://my-server.local/message-system",
             cainfo="mycainfo",
             computer_id="my-secure-id",
-            exchange_token="my-exchange-token",
+            exchange_token=b"my-exchange-token",
         )
 
-        self.assertEqual(server_response.server_uuid, "my-server-uuid")
+        self.assertEqual(server_response.server_api, "3.2")
+        self.assertEqual(server_response.server_uuid, b"my-server-uuid")
         self.assertEqual(
             server_response.messages,
             [{"type": "my-server-message-type", "other-value": 6}]

--- a/landscape/client/tests/test_registration.py
+++ b/landscape/client/tests/test_registration.py
@@ -35,7 +35,8 @@ class RegisterTestCase(TestCase):
         )
 
         self.exchange_messages_mock.return_value = ServerResponse(
-            "thisisaserveruuid",
+            "3.2",
+            b"thisisaserveruuid",
             [{"type": "set-id", "id": "mysecureid", "insecure-id": 1}],
         )
         registration_info = register(
@@ -45,7 +46,7 @@ class RegisterTestCase(TestCase):
 
         self.assertEqual(registration_info.insecure_id, 1)
         self.assertEqual(registration_info.secure_id, "mysecureid")
-        self.assertEqual(registration_info.server_uuid, "thisisaserveruuid")
+        self.assertEqual(registration_info.server_uuid, b"thisisaserveruuid")
 
     def test_exchange_http_code_error_404(self):
         """If a 404 is raised during the message exchange, a
@@ -129,7 +130,8 @@ class RegisterTestCase(TestCase):
         )
 
         self.exchange_messages_mock.return_value = ServerResponse(
-            server_uuid="thisisaserveruuid",
+            "3.2",
+            server_uuid=b"thisisaserveruuid",
             messages=[],
         )
 
@@ -149,7 +151,8 @@ class RegisterTestCase(TestCase):
         )
 
         self.exchange_messages_mock.return_value = ServerResponse(
-            server_uuid="thisisaserveruuid",
+            "3.2",
+            server_uuid=b"thisisaserveruuid",
             messages=[{"type": "unknown-message-type"}],
         )
 


### PR DESCRIPTION
After [this change](https://github.com/canonical/landscape-client/pull/262), we're not fully processing the server's response leading to some weird behavior... like the client & server getting stuck since the client is not providing the expected `exchange-token` or `sequence`. And we end up not processing any messages _hours_ after registration:

![Screenshot from 2024-10-07 20-31-02](https://github.com/user-attachments/assets/3f899798-46fa-46b5-80d0-825f22fc671d)

This behavior can be seen with the latest snap revisions from the `edge` channel (probably all revisions after revision 244).

Cause
---

Server responses look like:

```
{'client-accepted-types-hash': b'N\x82(WO\x9a\x11}E\xda\x91\xbb\xcf\xc6\\.',
 'messages': [],
 'next-exchange-token': b'3274f7dd-3e6a-4cfd-ae66-a43ed5845e42',
 'next-expected-sequence': 53,
 'server-api': '3.3',
 'server-uuid': b'f1a65772-c771-11ea-927a-0017a48f36ae'}
```

yet, the [ServerResponse](https://github.com/canonical/landscape-client/blob/4f2f0db536bf989674d5cd4c87ed81303b9c677f/landscape/client/exchange.py#L23) class looks like this:

```
@dataclass
class ServerResponse:
    """The HTTP response from the server after a message exchange."""

    server_uuid: str
    messages: List[Dict[str, Any]]
```

which means that after [this asdict](https://github.com/canonical/landscape-client/blob/4f2f0db536bf989674d5cd4c87ed81303b9c677f/landscape/client/broker/transport.py#L62), the response passed to `MessageExchange._handle_result` looks like this 👇 yet that function expects the original response _as is_.

```
{'server_uuid': b'f1a65772-c771-11ea-927a-0017a48f36ae', 'messages': []}
```

Fix
---

Process the full server response while retaining the original field types (i.e. keeping `bytes` instead of `str` as before) and `kebab-case` while processing the message.

The server provides `next-exchange-token` as `bytes` & the client has been storing it that way. We need to convert it to `str`  before using it as a header value in `landscape.client.exchange.exchange_messages`. After [this change](https://github.com/canonical/landscape-client/pull/262), we dropped that conversion which creates a bad header in `landscape.lib.fetch.fetch` (line 102):

```console
>>> [f"{key}: {value}" for (key, value) in {"X-Exchange-Token": "token"}.items()]
['X-Exchange-Token: token']
>>> [f"{key}: {value}" for (key, value) in {"X-Exchange-Token": b"token"}.items()]
["X-Exchange-Token: b'token'"]
```

When the server receives this bad exchange token, it forces the client to re-register creating a clone :(.