### PR TITLE
fix: add missing python3-yaml to runtime dependencies (LP: #2084586)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -42,7 +42,8 @@ Depends: ${python3:Depends}, ${misc:Depends}, ${extra:Depends},
          ${shlibs:Depends},
          landscape-common (= ${binary:Version}),
          python3-pycurl,
-	 python3-dbus
+	 python3-dbus,
+	 python3-yaml
 Description: Landscape administration system client
  Landscape is a web-based tool for managing Ubuntu systems. This
  package is necessary if you want your machine to be managed in a


### PR DESCRIPTION
python3-yaml is required for snap management when parsing snap assertions. Without it, the landscape-client service fails to start. It's often already installed in Ubuntu installations, so sometimes it works without being an explicit dependency.
This change ensures that it is an installed dependency.