### PR TITLE
Fix: monitor-only not being set properly when false/no passed in config

### DIFF
--- a/landscape/client/deployment.py
+++ b/landscape/client/deployment.py
@@ -3,10 +3,11 @@ import os.path
 import subprocess
 import sys
 import time
+from argparse import SUPPRESS
 from datetime import datetime
 from datetime import timezone
 from logging import debug
-from argparse import SUPPRESS
+from logging import info
 from typing import Sequence
 
 from twisted.logger import globalLogBeginner
@@ -14,8 +15,8 @@ from twisted.logger import globalLogBeginner
 from landscape import VERSION
 from landscape.client import DEFAULT_CONFIG
 from landscape.client import GROUP
-from landscape.client import USER
 from landscape.client import snap_http
+from landscape.client import USER
 from landscape.client.snap_utils import get_snap_info
 from landscape.client.upgraders import UPGRADE_MANAGERS
 from landscape.lib import logging
@@ -304,3 +305,23 @@ def generate_computer_title(auto_enroll_config):
         title = hostname
 
     return title
+
+
+def convert_arg_to_bool(value: str) -> bool:
+    """
+    Converts an argument provided that is in string format
+    to be a boolean value.
+    """
+    TRUTHY_VALUES = {"true", "yes", "y", "1", "on"}
+    FALSY_VALUES = {"false", "no", "n", "0", "off"}
+
+    if value.lower() in TRUTHY_VALUES:
+        return True
+    elif value.lower() in FALSY_VALUES:
+        return False
+    else:
+        info(
+            "Error. Invalid boolean provided in config or parameters. "
+            + "Defaulting to False.",
+        )
+        return False

--- a/landscape/client/tests/test_deployment.py
+++ b/landscape/client/tests/test_deployment.py
@@ -609,14 +609,12 @@ class ArgConversionTest(LandscapeTest):
 
     def test_true_values(self):
         TRUTHY_VALUES = {"true", "yes", "y", "1", "on", "TRUE", "Yes"}
-        val = True
         for t in TRUTHY_VALUES:
             val = convert_arg_to_bool(t)
             self.assertTrue(val)
 
     def test_false_values(self):
         FALSY_VALUES = {"false", "no", "n", "0", "off", "FALSE", "No"}
-        val = False
         for f in FALSY_VALUES:
             val = convert_arg_to_bool(f)
             self.assertFalse(val)
@@ -624,7 +622,6 @@ class ArgConversionTest(LandscapeTest):
     @mock.patch("landscape.client.deployment.info")
     def test_invalid_values(self, logging):
         INVALID_VALUES = {"invalid", "truthy", "2", "exit"}
-        val = False
         for i in INVALID_VALUES:
             val = convert_arg_to_bool(i)
             logging.assert_called_with(

--- a/landscape/client/tests/test_deployment.py
+++ b/landscape/client/tests/test_deployment.py
@@ -612,14 +612,14 @@ class ArgConversionTest(LandscapeTest):
         val = True
         for t in TRUTHY_VALUES:
             val = convert_arg_to_bool(t)
-        self.assertTrue(val)
+            self.assertTrue(val)
 
     def test_false_values(self):
         FALSY_VALUES = {"false", "no", "n", "0", "off", "FALSE", "No"}
         val = False
         for f in FALSY_VALUES:
             val = convert_arg_to_bool(f)
-        self.assertFalse(val)
+            self.assertFalse(val)
 
     @mock.patch("landscape.client.deployment.info")
     def test_invalid_values(self, logging):
@@ -631,4 +631,4 @@ class ArgConversionTest(LandscapeTest):
                 "Error. Invalid boolean provided in config or parameters. "
                 + "Defaulting to False.",
             )
-        self.assertFalse(val)
+            self.assertFalse(val)

--- a/landscape/client/tests/test_watchdog.py
+++ b/landscape/client/tests/test_watchdog.py
@@ -12,8 +12,8 @@ from twisted.internet.defer import succeed
 from twisted.internet.utils import getProcessOutput
 from twisted.python.fakepwd import UserDatabase
 
-from landscape.client import USER
 import landscape.client.watchdog
+from landscape.client import USER
 from landscape.client.amp import ComponentConnector
 from landscape.client.broker.amp import RemoteBrokerConnector
 from landscape.client.reactor import LandscapeReactor
@@ -1147,8 +1147,27 @@ class WatchDogOptionsTest(LandscapeTest):
         self.config.load(["--monitor-only"])
         self.assertEqual(self.config.get_enabled_daemons(), [Broker, Monitor])
 
+    def test_monitor_only_false(self):
+        self.config.load(["--monitor-only", "false"])
+        self.assertEqual(
+            self.config.get_enabled_daemons(),
+            [Broker, Monitor, Manager],
+        )
+
     def test_default_daemons(self):
         self.config.load([])
+        self.assertEqual(
+            self.config.get_enabled_daemons(),
+            [Broker, Monitor, Manager],
+        )
+
+    @mock.patch("landscape.client.watchdog.info")
+    def test_monitor_only_invalid_entry(self, logging):
+        self.config.load(["--monitor-only", "invalid-option"])
+        logging.assert_called_once_with(
+            "Error. Invalid boolean provided in config or parameters. ",
+            "Defaulting to False.",
+        )
         self.assertEqual(
             self.config.get_enabled_daemons(),
             [Broker, Monitor, Manager],

--- a/landscape/client/tests/test_watchdog.py
+++ b/landscape/client/tests/test_watchdog.py
@@ -1161,12 +1161,12 @@ class WatchDogOptionsTest(LandscapeTest):
             [Broker, Monitor, Manager],
         )
 
-    @mock.patch("landscape.client.watchdog.info")
+    @mock.patch("landscape.client.deployment.info")
     def test_monitor_only_invalid_entry(self, logging):
         self.config.load(["--monitor-only", "invalid-option"])
         logging.assert_called_once_with(
-            "Error. Invalid boolean provided in config or parameters. ",
-            "Defaulting to False.",
+            "Error. Invalid boolean provided in config or parameters. "
+            + "Defaulting to False.",
         )
         self.assertEqual(
             self.config.get_enabled_daemons(),

--- a/landscape/client/watchdog.py
+++ b/landscape/client/watchdog.py
@@ -32,6 +32,7 @@ from landscape.client.broker.amp import RemoteBrokerConnector
 from landscape.client.broker.amp import RemoteManagerConnector
 from landscape.client.broker.amp import RemoteMonitorConnector
 from landscape.client.deployment import Configuration
+from landscape.client.deployment import convert_arg_to_bool
 from landscape.client.deployment import init_logging
 from landscape.client.reactor import LandscapeReactor
 from landscape.lib.bootstrap import BootstrapDirectory
@@ -521,7 +522,7 @@ class WatchDogConfiguration(Configuration):
         )
         parser.add_argument(
             "--monitor-only",
-            type=self.convert_arg_to_bool,
+            type=convert_arg_to_bool,
             nargs="?",
             const=True,
             default=False,
@@ -536,22 +537,6 @@ class WatchDogConfiguration(Configuration):
         if not self.monitor_only:
             daemons.append(Manager)
         return daemons
-
-    def convert_arg_to_bool(self, value: str) -> bool:
-        """
-        Converts an argument provided that is in string format
-        to be a boolean value.
-        """
-        if value.lower() in {"true", "yes", "1"}:
-            return True
-        elif value.lower() in {"false", "no", "0"}:
-            return False
-        else:
-            info(
-                "Error. Invalid boolean provided in config or parameters. ",
-                "Defaulting to False.",
-            )
-            return False
 
 
 def daemonize():

--- a/landscape/client/watchdog.py
+++ b/landscape/client/watchdog.py
@@ -4,7 +4,6 @@ The WatchDog must run as root, because it spawns the Landscape Manager.
 
 The main C{landscape-client} program uses this watchdog.
 """
-
 import errno
 import os
 import pwd
@@ -26,8 +25,8 @@ from twisted.internet.defer import succeed
 from twisted.internet.error import ProcessExitedAlready
 from twisted.internet.protocol import ProcessProtocol
 
-from landscape.client import IS_SNAP
 from landscape.client import GROUP
+from landscape.client import IS_SNAP
 from landscape.client import USER
 from landscape.client.broker.amp import RemoteBrokerConnector
 from landscape.client.broker.amp import RemoteManagerConnector
@@ -522,7 +521,10 @@ class WatchDogConfiguration(Configuration):
         )
         parser.add_argument(
             "--monitor-only",
-            action="store_true",
+            type=self.convert_arg_to_bool,
+            nargs="?",
+            const=True,
+            default=False,
             help="Don't enable management features. This is "
             "useful if you want to run the client as a non-root "
             "user.",
@@ -534,6 +536,22 @@ class WatchDogConfiguration(Configuration):
         if not self.monitor_only:
             daemons.append(Manager)
         return daemons
+
+    def convert_arg_to_bool(self, value: str) -> bool:
+        """
+        Converts an argument provided that is in string format
+        to be a boolean value.
+        """
+        if value.lower() in {"true", "yes", "1"}:
+            return True
+        elif value.lower() in {"false", "no", "0"}:
+            return False
+        else:
+            info(
+                "Error. Invalid boolean provided in config or parameters. ",
+                "Defaulting to False.",
+            )
+            return False
 
 
 def daemonize():


### PR DESCRIPTION
## Manual Testing
### Verify Bug
- Run new testcases provided (current branch) checking for when false parameter is sent in using old watchdog file
- Test cases will fail as Manager daemon is not spawned
### Verify Fix
- Run same testcases as above using new watchdog
- See that Manager daemon is spawned in cases where false is sent as parameter