### PR TITLE
Fix: SSL Certificates not properly surfaced

### DIFF
--- a/landscape/lib/fetch.py
+++ b/landscape/lib/fetch.py
@@ -2,6 +2,7 @@ import io
 import os
 import sys
 from argparse import ArgumentParser
+from logging import warning
 
 from twisted.internet.defer import DeferredList
 from twisted.internet.threads import deferToThread
@@ -94,6 +95,13 @@ def fetch(
             curl.setopt(pycurl.READFUNCTION, output.read)
 
     if cainfo and url.startswith("https:"):
+        if not os.access(cainfo, os.R_OK):
+            warning(
+                "SSL certificate provided is not accessible by landscape "
+                + "client. Please place in directory that is readable such "
+                + "as '/etc/ssl/certs'",
+            )
+            # log error here
         curl.setopt(pycurl.CAINFO, networkString(cainfo))
 
     if headers:

--- a/landscape/lib/tests/test_fetch.py
+++ b/landscape/lib/tests/test_fetch.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 from threading import local
+from unittest import mock
 
 import pycurl
 from twisted.internet.defer import FirstError
@@ -190,6 +191,17 @@ class FetchTest(
         result = fetch("http://example.com", cainfo="cainfo", curl=curl)
         self.assertEqual(result, b"result")
         self.assertTrue(pycurl.CAINFO not in curl.options)
+
+    @mock.patch("landscape.lib.fetch.warning")
+    def test_cainfo_inaccessible_cert(self, logging):
+        curl = CurlStub(b"result")
+        result = fetch("https://example.com", cainfo="cainfo", curl=curl)
+        self.assertEqual(result, b"result")
+        logging.assert_called_once_with(
+            "SSL certificate provided is not accessible by landscape "
+            + "client. Please place in directory that is readable such "
+            + "as '/etc/ssl/certs'",
+        )
 
     def test_headers(self):
         curl = CurlStub(b"result")


### PR DESCRIPTION
## Manual Testing
### Verify Bug
- Download landscape client and place self signed server certificate in an unreadable directory by landscape
- Try to connect client to server using the following command
`landscape-config --account standalone --url https://<server-ip>/message-system --ping-url https://server-ip/ping -k ssl-cert-location `
- Code should fail and provide no information as to why it fails
### Verify Fix
- Repeat above steps but instead using this version
- Verify that warning message is provided by logs