### PR TITLE
fix: get tests passing on plucky

### DIFF
--- a/landscape/client/broker/tests/test_transport.py
+++ b/landscape/client/broker/tests/test_transport.py
@@ -193,16 +193,10 @@ class HTTPTransportTest(LandscapeTest):
             message_api=b"X.Y",
         )
 
-        def got_result(ignored):
+        def got_result(failure):
             self.assertIs(r.request, None)
             self.assertIs(r.content, None)
-            logfile_value = self.logfile.getvalue()
-            # pycurl error messages vary by version.
-            # First is for <= noble, second for > noble.
-            self.assertTrue(
-                "server certificate verification failed" in logfile_value
-                or "SSL certificate problem" in logfile_value,
-            )
+            self.assertEqual(failure.value.error_code, 60)
 
         result.addErrback(got_result)
         return result

--- a/landscape/lib/testing.py
+++ b/landscape/lib/testing.py
@@ -687,7 +687,10 @@ class FakeReactor(EventHandlingReactorMixin):
             try:
                 deferred = f(*args, **kwargs)
 
-                if hasattr(deferred, "result") and isinstance(deferred.result, Failure):
+                if (
+                    hasattr(deferred, "result")
+                    and isinstance(deferred.result, Failure)
+                ):
                     # Required for some failures to get GC'd properly flushed.
                     # Twisted did this in versions < 24.10, but now we have to.
                     deferred.result.cleanFailure()

--- a/landscape/lib/testing.py
+++ b/landscape/lib/testing.py
@@ -691,8 +691,8 @@ class FakeReactor(EventHandlingReactorMixin):
                     hasattr(deferred, "result")
                     and isinstance(deferred.result, Failure)
                 ):
-                    # Required for some failures to get GC'd properly flushed.
-                    # Twisted did this in versions < 24.10, but now we have to.
+                    # Required for failures to get GC'd and properly flushed.
+                    # Twisted did this for us in versions < 24.10.
                     deferred.result.cleanFailure()
             except Exception:
                 if call.active:


### PR DESCRIPTION
Twisted changed a little bit - it used to run `cleanFailure` on `Failure` instances in the `defer` code but no longer does in the version available in plucky (python3-twisted 24.10).

This change does `cleanFailure` in the `FakeReactor` we use for some tests. This allows tests that rely on catching and flushing `Failure`s to succeed.