### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,7 +52,6 @@ apps:
       - scsi-generic
       - shutdown
       - snapd-control-managed
-      - snapd-control
       - system-observe
       - account-control
       - process-control


### PR DESCRIPTION
Snapstore permissions can't handle two snapd-control interfaces.

Removing the original one. Doesn't change anything as the attribute needs setting separately after the snap is installed to use it. Default behaviour should be identical.
