### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,7 +51,7 @@ apps:
       - network-observe
       - scsi-generic
       - shutdown
-      - snapd-control-managed
+      - snapd-control
       - system-observe
       - account-control
       - process-control


### PR DESCRIPTION
Fix: removed snapd-control-managed from apps stanza. This still works but means that the snap declaration on the store does not need changing - which seems to break existing installations.