### PR TITLE
fix: log rotation

### DIFF
--- a/debian/landscape-client.logrotate
+++ b/debian/landscape-client.logrotate
@@ -1,4 +1,9 @@
-/var/log/landscape/watchdog.log /var/log/landscape/monitor.log /var/log/landscape/broker.log /var/log/landscape/manager.log {
+/var/log/landscape/watchdog.log
+/var/log/landscape/monitor.log
+/var/log/landscape/broker.log
+/var/log/landscape/manager.log
+/var/log/landscape/landscape-config.log
+{
     weekly
     rotate 4
     missingok
@@ -11,7 +16,11 @@
     endscript
 }
 
-/var/log/landscape/package-changer.log /var/log/landscape/package-reporter.log /var/log/landscape/sysinfo.log /var/log/landscape/release-upgrader.log {
+/var/log/landscape/package-changer.log
+/var/log/landscape/package-reporter.log
+/var/log/landscape/sysinfo.log
+/var/log/landscape/release-upgrader.log
+{
     weekly
     rotate 4
     missingok

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ plugs:
       - /var/lib/snapd/hostfs/var/lib/ubuntu-advantage/status.json
   snapd-control-managed:
     interface: snapd-control
-    refresh-schedule: managed  
+    refresh-schedule: managed
 
 slots:
   annotations:
@@ -64,6 +64,10 @@ apps:
     plugs:
       - network
       - hardware-observe
+  logrotate:
+    command: usr/sbin/logrotate -s /tmp/logrotate-status $SNAP/etc/logrotate.conf
+    daemon: simple
+    timer: sun,02:00~03:00
 
 # Previously, the client's data was stored in $SNAP_DATA
 #  which led to duplicate machine entries after reverting
@@ -129,3 +133,12 @@ parts:
       # Copy the scripts over
       mkdir -p ${SNAPCRAFT_PRIME}/usr/bin/
       cp -r ${SNAPCRAFT_PART_SRC}/scripts/. ${SNAPCRAFT_PRIME}/usr/bin/
+  logrotate:
+    plugin: nil
+    source: .
+    stage-packages:
+      - logrotate
+    override-prime: |
+      craftctl default
+      cp ${SNAPCRAFT_PART_SRC}/debian/landscape-client.logrotate ${SNAPCRAFT_PRIME}/etc/logrotate.conf
+      sed -i 's/systemctl kill --signal=USR1 --kill-who=main/snapctl restart/' ${SNAPCRAFT_PRIME}/etc/logrotate.conf


### PR DESCRIPTION
This change allows the landscape-client snap to periodically rotate log files. This issue was reported [here](https://forum.snapcraft.io/t/rotating-landscape-client-logs/44509).

The new `landscape-client.logrotate` daemon will run once a week on Sundays some time between 2am & 3am. After rotation, the `landscape-client` service is restarted.

---

I tested this with `logrotate` configured to rotate logs every hour with a 10kb max file size. The log rotation is working as expected:

```console
$ ls /var/snap/landscape-client/current/var/log/landscape/ -lah
total 3.9M
drwxr-xr-x 2 root root 4.0K Jan 13 16:00 .
drwxr-xr-x 3 root root 4.0K Jan 13 11:16 ..
-rw-r--r-- 1 root root 356K Jan 13 16:01 broker.log
-rw-r--r-- 1 root root 3.3M Jan 13 16:00 broker.log.1
-rw-r--r-- 1 root root  24K Jan 13 13:44 broker.log.2.gz
-rw-r--r-- 1 root root 116K Jan 13 13:21 broker.log.3.gz
-rw-r--r-- 1 root root   93 Jan 13 11:44 landscape-config.log
-rw-r--r-- 1 root root 2.3K Jan 13 16:15 manager.log
-rw-r--r-- 1 root root  25K Jan 13 16:00 manager.log.1
-rw-r--r-- 1 root root 2.0K Jan 13 13:21 manager.log.2.gz
-rw-r--r-- 1 root root 3.7K Jan 13 16:00 monitor.log
-rw-r--r-- 1 root root  56K Jan 13 16:00 monitor.log.1
-rw-r--r-- 1 root root 4.5K Jan 13 13:21 monitor.log.2.gz
-rw-r--r-- 1 root root   77 Jan 13 16:00 watchdog.log
-rw-r--r-- 1 root root 6.0K Jan 13 16:00 watchdog.log.1

$ snap logs landscape-client.logrotate # after rotation triggered by snapd timer
2025-01-13T16:20:06+03:00 systemd[1]: Started snap.landscape-client.logrotate.service - Service for snap application landscape-client.logrotate.
2025-01-13T16:20:06+03:00 systemd[1]: Stopping snap.landscape-client.logrotate.service - Service for snap application landscape-client.logrotate...
2025-01-13T16:20:06+03:00 systemd[1]: snap.landscape-client.logrotate.service: Killing process 730575 (snapctl) with signal SIGKILL.
2025-01-13T16:20:06+03:00 systemd[1]: snap.landscape-client.logrotate.service: Deactivated successfully.
2025-01-13T16:20:06+03:00 systemd[1]: Stopped snap.landscape-client.logrotate.service - Service for snap application landscape-client.logrotate.
2025-01-13T16:20:06+03:00 systemd[1]: Started snap.landscape-client.logrotate.service - Service for snap application landscape-client.logrotate.
2025-01-13T16:20:06+03:00 systemd[1]: snap.landscape-client.logrotate.service: Deactivated successfully.

$ ls /var/snap/landscape-client/current/var/log/landscape/ -lah
total 628K
drwxr-xr-x 2 root root 4.0K Jan 13 16:20 .
drwxr-xr-x 3 root root 4.0K Jan 13 11:16 ..
-rw-r--r-- 1 root root  386 Jan 13 16:20 broker.log
-rw-r--r-- 1 root root 432K Jan 13 16:20 broker.log.1
-rw-r--r-- 1 root root  24K Jan 13 13:44 broker.log.3.gz
-rw-r--r-- 1 root root 116K Jan 13 13:21 broker.log.4.gz
-rw-r--r-- 1 root root   93 Jan 13 11:44 landscape-config.log
-rw-r--r-- 1 root root 1.8K Jan 13 16:20 manager.log
-rw-r--r-- 1 root root 3.0K Jan 13 16:20 manager.log.1
-rw-r--r-- 1 root root 2.0K Jan 13 13:21 manager.log.3.gz
-rw-r--r-- 1 root root 3.0K Jan 13 16:20 monitor.log
-rw-r--r-- 1 root root 6.3K Jan 13 16:20 monitor.log.1
-rw-r--r-- 1 root root 4.5K Jan 13 13:21 monitor.log.3.gz
-rw-r--r-- 1 root root   77 Jan 13 16:20 watchdog.log
-rw-r--r-- 1 root root  259 Jan 13 16:20 watchdog.log.1

$ systemctl status snap.landscape-client.landscape-client.service
systemctl status snap.landscape-client.landscape-client.service
● snap.landscape-client.landscape-client.service - Service for snap application landscape-client.landscape-client
     Loaded: loaded (/etc/systemd/system/snap.landscape-client.landscape-client.service; enabled; preset: enabled)
     Active: active (running) since Mon 2025-01-13 16:20:06 EAT; 31s ago
[...]
```