### PR TITLE
feat: add support for .sources when applying repository profiles

### DIFF
--- a/landscape/client/manager/aptsources.py
+++ b/landscape/client/manager/aptsources.py
@@ -27,6 +27,11 @@ class AptSources(ManagerPlugin):
     SOURCES_LIST_D = "/etc/apt/sources.list.d"
     TRUSTED_GPG_D = "/etc/apt/trusted.gpg.d"
 
+    """
+    Valid file patterns for one-line and Deb822-style sources, respectively.
+    """
+    SOURCES_LIST_D_FILE_PATTERNS = ["*.list", "*.sources"]
+
     def register(self, registry):
         super().register(registry)
         registry.register_message(
@@ -142,11 +147,10 @@ class AptSources(ManagerPlugin):
         )
 
         if manage_sources_list_d not in FALSE_VALUES:
-            patterns = ["*.list", "*.sources"]
-            for pattern in patterns:
-                filenames = glob.glob(os.path.join(
-                    self.SOURCES_LIST_D, pattern
-                ))
+            for pattern in self.SOURCES_LIST_D_FILE_PATTERNS:
+                filenames = glob.glob(
+                    os.path.join(self.SOURCES_LIST_D, pattern)
+                )
                 for filename in filenames:
                     shutil.move(filename, f"{filename}.save")
 

--- a/landscape/client/manager/aptsources.py
+++ b/landscape/client/manager/aptsources.py
@@ -140,10 +140,15 @@ class AptSources(ManagerPlugin):
             "manage_sources_list_d",
             True,
         )
+
         if manage_sources_list_d not in FALSE_VALUES:
-            filenames = glob.glob(os.path.join(self.SOURCES_LIST_D, "*.list"))
-            for filename in filenames:
-                shutil.move(filename, f"{filename}.save")
+            patterns = ["*.list", "*.sources"]
+            for pattern in patterns:
+                filenames = glob.glob(os.path.join(
+                    self.SOURCES_LIST_D, pattern
+                ))
+                for filename in filenames:
+                    shutil.move(filename, f"{filename}.save")
 
         for source in sources:
             filename = os.path.join(

--- a/landscape/client/manager/tests/test_aptsources.py
+++ b/landscape/client/manager/tests/test_aptsources.py
@@ -260,8 +260,9 @@ class AptSourcesTests(LandscapeTest):
 
     def test_renames_sources_list_d(self):
         """
-        The sources files in sources.list.d are renamed to .save when a message
-        is received if config says to manage them, which is the default.
+        The sources files (.list, .sources) in sources.list.d
+        are renamed to .save when a message is received
+        if config says to manage them, which is the default.
         """
         with open(
             os.path.join(self.sourceslist.SOURCES_LIST_D, "file1.list"),
@@ -274,6 +275,12 @@ class AptSourcesTests(LandscapeTest):
             "w",
         ) as sources2:
             sources2.write("ok\n")
+
+        with open(
+            os.path.join(self.sourceslist.SOURCES_LIST_D, "file3.sources"),
+            "w",
+        ) as sources3:
+            sources3.write("source content\n")
 
         self.manager.dispatch_message(
             {
@@ -308,10 +315,20 @@ class AptSourcesTests(LandscapeTest):
             ),
         )
 
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(
+                    self.sourceslist.SOURCES_LIST_D,
+                    "file3.sources.save",
+                ),
+            ),
+        )
+
     def test_does_not_rename_sources_list_d(self):
         """
-        The sources files in sources.list.d are not renamed to .save when a
-        message is received if config says not to manage them.
+        The sources files (.list, .sources) in sources.list.d
+        are renamed to .save when a message is received
+        if config says to manage them, which is the default.
         """
         with open(
             os.path.join(self.sourceslist.SOURCES_LIST_D, "file1.list"),
@@ -324,6 +341,20 @@ class AptSourcesTests(LandscapeTest):
             "w",
         ) as sources2:
             sources2.write("ok\n")
+
+        with open(
+            os.path.join(self.sourceslist.SOURCES_LIST_D, "file3.sources"),
+            "w",
+        ) as sources3:
+            sources3.write("ok\n")
+
+        with open(
+            os.path.join(
+                self.sourceslist.SOURCES_LIST_D, "file4.sources.save"
+            ),
+            "w",
+        ) as sources4:
+            sources4.write("ok\n")
 
         self.manager.config.manage_sources_list_d = False
         self.manager.dispatch_message(
@@ -341,6 +372,12 @@ class AptSourcesTests(LandscapeTest):
             ),
         )
 
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(self.sourceslist.SOURCES_LIST_D, "file3.sources"),
+            ),
+        )
+
         self.assertFalse(
             os.path.exists(
                 os.path.join(
@@ -350,11 +387,29 @@ class AptSourcesTests(LandscapeTest):
             ),
         )
 
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(
+                    self.sourceslist.SOURCES_LIST_D,
+                    "file3.sources.save",
+                ),
+            ),
+        )
+
         self.assertTrue(
             os.path.exists(
                 os.path.join(
                     self.sourceslist.SOURCES_LIST_D,
                     "file2.list.save",
+                ),
+            ),
+        )
+
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(
+                    self.sourceslist.SOURCES_LIST_D,
+                    "file4.sources.save",
                 ),
             ),
         )

--- a/landscape/client/manager/tests/test_aptsources.py
+++ b/landscape/client/manager/tests/test_aptsources.py
@@ -264,23 +264,24 @@ class AptSourcesTests(LandscapeTest):
         are renamed to .save when a message is received
         if config says to manage them, which is the default.
         """
+        FILE_1_LIST = os.path.join(
+            self.sourceslist.SOURCES_LIST_D, "file1.list"
+        )
+
+        FILE_2_SOURCES = os.path.join(
+            self.sourceslist.SOURCES_LIST_D, "file2.sources"
+        )
         with open(
-            os.path.join(self.sourceslist.SOURCES_LIST_D, "file1.list"),
+            FILE_1_LIST,
             "w",
-        ) as sources1:
-            sources1.write("ok\n")
+        ) as source1:
+            source1.write("ok\n")
 
         with open(
-            os.path.join(self.sourceslist.SOURCES_LIST_D, "file2.list.save"),
+            FILE_2_SOURCES,
             "w",
-        ) as sources2:
-            sources2.write("ok\n")
-
-        with open(
-            os.path.join(self.sourceslist.SOURCES_LIST_D, "file3.sources"),
-            "w",
-        ) as sources3:
-            sources3.write("source content\n")
+        ) as source2:
+            source2.write("ok\n")
 
         self.manager.dispatch_message(
             {
@@ -292,69 +293,42 @@ class AptSourcesTests(LandscapeTest):
         )
 
         self.assertFalse(
-            os.path.exists(
-                os.path.join(self.sourceslist.SOURCES_LIST_D, "file1.list"),
-            ),
+            os.path.exists(FILE_1_LIST),
+        )
+
+        self.assertFalse(os.path.exists(FILE_2_SOURCES))
+
+        self.assertTrue(
+            os.path.exists(f"{FILE_1_LIST}.save"),
         )
 
         self.assertTrue(
-            os.path.exists(
-                os.path.join(
-                    self.sourceslist.SOURCES_LIST_D,
-                    "file1.list.save",
-                ),
-            ),
-        )
-
-        self.assertTrue(
-            os.path.exists(
-                os.path.join(
-                    self.sourceslist.SOURCES_LIST_D,
-                    "file2.list.save",
-                ),
-            ),
-        )
-
-        self.assertTrue(
-            os.path.exists(
-                os.path.join(
-                    self.sourceslist.SOURCES_LIST_D,
-                    "file3.sources.save",
-                ),
-            ),
+            os.path.exists(f"{FILE_2_SOURCES}.save"),
         )
 
     def test_does_not_rename_sources_list_d(self):
         """
         The sources files (.list, .sources) in sources.list.d
-        are renamed to .save when a message is received
-        if config says to manage them, which is the default.
+        are not renamed to .save when a message is received
+        if config says not to manage them
         """
-        with open(
-            os.path.join(self.sourceslist.SOURCES_LIST_D, "file1.list"),
-            "w",
-        ) as sources1:
-            sources1.write("ok\n")
+        FILE_3_LIST = os.path.join(
+            self.sourceslist.SOURCES_LIST_D, "file3.list"
+        )
 
+        FILE_4_SOURCES = os.path.join(
+            self.sourceslist.SOURCES_LIST_D, "file4.sources"
+        )
         with open(
-            os.path.join(self.sourceslist.SOURCES_LIST_D, "file2.list.save"),
+            FILE_3_LIST,
             "w",
-        ) as sources2:
-            sources2.write("ok\n")
-
+        ) as source3:
+            source3.write("ok\n")
         with open(
-            os.path.join(self.sourceslist.SOURCES_LIST_D, "file3.sources"),
+            FILE_4_SOURCES,
             "w",
-        ) as sources3:
-            sources3.write("ok\n")
-
-        with open(
-            os.path.join(
-                self.sourceslist.SOURCES_LIST_D, "file4.sources.save"
-            ),
-            "w",
-        ) as sources4:
-            sources4.write("ok\n")
+        ) as source4:
+            source4.write("ok\n")
 
         self.manager.config.manage_sources_list_d = False
         self.manager.dispatch_message(
@@ -367,51 +341,19 @@ class AptSourcesTests(LandscapeTest):
         )
 
         self.assertTrue(
-            os.path.exists(
-                os.path.join(self.sourceslist.SOURCES_LIST_D, "file1.list"),
-            ),
+            os.path.exists(FILE_3_LIST),
         )
 
         self.assertTrue(
-            os.path.exists(
-                os.path.join(self.sourceslist.SOURCES_LIST_D, "file3.sources"),
-            ),
+            os.path.exists(FILE_4_SOURCES),
         )
 
         self.assertFalse(
-            os.path.exists(
-                os.path.join(
-                    self.sourceslist.SOURCES_LIST_D,
-                    "file1.list.save",
-                ),
-            ),
+            os.path.exists(f"{FILE_3_LIST}.save"),
         )
 
         self.assertFalse(
-            os.path.exists(
-                os.path.join(
-                    self.sourceslist.SOURCES_LIST_D,
-                    "file3.sources.save",
-                ),
-            ),
-        )
-
-        self.assertTrue(
-            os.path.exists(
-                os.path.join(
-                    self.sourceslist.SOURCES_LIST_D,
-                    "file2.list.save",
-                ),
-            ),
-        )
-
-        self.assertTrue(
-            os.path.exists(
-                os.path.join(
-                    self.sourceslist.SOURCES_LIST_D,
-                    "file4.sources.save",
-                ),
-            ),
+            os.path.exists(f"{FILE_4_SOURCES}.save"),
         )
 
     def test_create_landscape_sources(self):


### PR DESCRIPTION
https://bugs.launchpad.net/landscape-client/+bug/2087852

## Testing Current Behavior
In client container (on main brain):
```
cd /etc/apt/sources.list.d
# mock .list and .sources files (if there are none already)
sudo touch hello.list
sudo touch hello.sources
```
In server container: `./dev/advicedog`
Now connect the client container to the server container. 
Then, open another tab in the server container:
```
source ./dev/setup-api
# Create dummy repository profile
lsapi create-repository-profile hello-world
# Apply to all computers
lsapi associate-repository-profile --all-computers hello-world
```
Observe the client container. After having the repository profile applied, notice that `.list` files have `.save` appended, while `.sources` files do not.
```
ls /etc/apt/sources.list.d
# should see hello.sources and hello.list.save
```
## Testing Changes 

Now, checkout my branch in the client container:
```
git fetch --all
git checkout lndeng-1985-repository-profile-not-acting-on-source-files
# Create new test files
sudo touch hello2.sources
sudo touch hello2.list
```

In the server container, try applying a repository profile again:

```
lsapi create-repository-profile hello-world2
lsapi associate-repository-profile --all-computers hello-world2
```
Now, the client container should have .save appended to both `.sources` and `.list` files in `/etc/apt/sources.list.d`:

```
ls /etc/apt/sources.list.d
# should see hello2.sources and hello2.list.save
```



### Running tests:

`./bin/test canonical.landscape.api.auth.tests.test_oidc`

