### PR TITLE
refactor: delete `landscape/lib/compat.py`

### DIFF
--- a/landscape/client/broker/exchange.py
+++ b/landscape/client/broker/exchange.py
@@ -858,6 +858,12 @@ class MessageExchange:
         # be 3.2, because it's the one that didn't have this field.
         server_api = result.get("server-api", b"3.2")
 
+        if not isinstance(server_api, bytes):
+            # The "server-api" field in the bpickle payload sent by the server
+            # is a string, however in Python 3 we need to convert it to bytes,
+            # since that's what the rest of the code expects.
+            server_api = server_api.encode()
+
         if is_version_higher(server_api, message_store.get_server_api()):
             # The server can handle a message API that is higher than the one
             # we're currently using. If the highest server API is greater than

--- a/landscape/client/broker/exchange.py
+++ b/landscape/client/broker/exchange.py
@@ -352,7 +352,6 @@ from landscape import CLIENT_API
 from landscape import DEFAULT_SERVER_API
 from landscape import SERVER_API
 from landscape.lib.backoff import ExponentialBackoff
-from landscape.lib.compat import _PY3
 from landscape.lib.fetch import HTTPCodeError
 from landscape.lib.fetch import PyCurlError
 from landscape.lib.format import format_delta
@@ -859,12 +858,6 @@ class MessageExchange:
         # be 3.2, because it's the one that didn't have this field.
         server_api = result.get("server-api", b"3.2")
 
-        if _PY3 and not isinstance(server_api, bytes):
-            # The "server-api" field in the bpickle payload sent by the server
-            # is a string, however in Python 3 we need to convert it to bytes,
-            # since that's what the rest of the code expects.
-            server_api = server_api.encode()
-
         if is_version_higher(server_api, message_store.get_server_api()):
             # The server can handle a message API that is higher than the one
             # we're currently using. If the highest server API is greater than
@@ -955,6 +948,6 @@ def get_accepted_types_diff(old_types, new_types):
 
 def maybe_bytes(thing):
     """Return a py3 ascii string from maybe py2 bytes."""
-    if _PY3 and isinstance(thing, bytes):
+    if isinstance(thing, bytes):
         return thing.decode("ascii")
     return thing

--- a/landscape/client/broker/server.py
+++ b/landscape/client/broker/server.py
@@ -201,6 +201,14 @@ class BrokerServer:
             during the next regularly scheduled exchange.
         @return: The message identifier created when queuing C{message}.
         """
+        if b"type" in message:
+            # XXX We are getting called by a python2 process.
+            # This occurs in the the specific case of a landscape-driven
+            # release upgrade to bionic, where the upgrading process is still
+            # running under python2.7. Therefore we do backward-compatible
+            # translation of byte keys in the sent message
+            message = {k.decode("ascii"): v for k, v in message.items()}
+            message["type"] = message["type"].decode("ascii")
         if isinstance(session_id, bool) and message["type"] in (
             "operation-result",
             "change-packages-result",

--- a/landscape/client/broker/server.py
+++ b/landscape/client/broker/server.py
@@ -48,7 +48,6 @@ from twisted.internet.defer import Deferred
 
 from landscape.client.amp import remote
 from landscape.client.manager.manager import FAILED
-from landscape.lib.compat import _PY3
 from landscape.lib.twisted_util import gather_results
 
 
@@ -202,14 +201,6 @@ class BrokerServer:
             during the next regularly scheduled exchange.
         @return: The message identifier created when queuing C{message}.
         """
-        if b"type" in message and _PY3:
-            # XXX We are getting called by a python2 process.
-            # This occurs in the the specific case of a landscape-driven
-            # release upgrade to bionic, where the upgrading process is still
-            # running under python2.7. Therefore we do backward-compatible
-            # translation of byte keys in the sent message
-            message = {k.decode("ascii"): v for k, v in message.items()}
-            message["type"] = message["type"].decode("ascii")
         if isinstance(session_id, bool) and message["type"] in (
             "operation-result",
             "change-packages-result",

--- a/landscape/client/broker/tests/test_registration.py
+++ b/landscape/client/broker/tests/test_registration.py
@@ -8,7 +8,6 @@ from landscape.client.broker.registration import RegistrationError
 from landscape.client.broker.tests.helpers import BrokerConfigurationHelper
 from landscape.client.broker.tests.helpers import RegistrationHelper
 from landscape.client.tests.helpers import LandscapeTest
-from landscape.lib.compat import _PY3
 from landscape.lib.persist import Persist
 
 
@@ -328,14 +327,8 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         self.assertEqual(expected, messages[0]["tags"])
 
         logs = self.logfile.getvalue().strip()
-        # XXX This is not nice, as it has the origin in a non-consistent way of
-        # using logging. self.logfile is a cStringIO in Python 2 and
-        # io.StringIO in Python 3. This results in reading bytes in Python 2
-        # and unicode in Python 3, but a drop-in replacement of cStringIO with
-        # io.StringIO in Python 2 is not working. However, we compare bytes
-        # here, to circumvent that problem.
-        if _PY3:
-            logs = logs.encode("utf-8")
+        logs = logs.encode("utf-8")
+
         self.assertEqual(
             logs,
             b"INFO: Queueing message to register with account "

--- a/landscape/client/broker/tests/test_server.py
+++ b/landscape/client/broker/tests/test_server.py
@@ -137,28 +137,6 @@ class BrokerServerTest(LandscapeTest):
         self.assertMessages(self.mstore.get_pending_messages(), [message])
         self.assertTrue(self.exchanger.is_urgent())
 
-    def test_send_message_from_py27_upgrader(self):
-        """
-        If we receive release-upgrade results from a py27 release upgrader,
-        it gets translated to a py3-compatible message.
-        """
-        legacy_message = {
-            b"type": b"change-packages-result",
-            b"operation-id": 99,
-            b"result-code": 123,
-        }
-        self.mstore.set_accepted_types(["change-packages-result"])
-        self.broker.send_message(legacy_message, True)
-        expected = [
-            {
-                "type": "change-packages-result",
-                "operation-id": 99,
-                "result-code": 123,
-            },
-        ]
-        self.assertMessages(self.mstore.get_pending_messages(), expected)
-        self.assertTrue(self.exchanger.is_urgent())
-
     def test_is_pending(self):
         """
         The L{BrokerServer.is_pending} method indicates if a message with

--- a/landscape/client/broker/tests/test_server.py
+++ b/landscape/client/broker/tests/test_server.py
@@ -137,6 +137,28 @@ class BrokerServerTest(LandscapeTest):
         self.assertMessages(self.mstore.get_pending_messages(), [message])
         self.assertTrue(self.exchanger.is_urgent())
 
+    def test_send_message_from_py27_upgrader(self):
+        """
+        If we receive release-upgrade results from a py27 release upgrader,
+        it gets translated to a py3-compatible message.
+        """
+        legacy_message = {
+            b"type": b"change-packages-result",
+            b"operation-id": 99,
+            b"result-code": 123,
+        }
+        self.mstore.set_accepted_types(["change-packages-result"])
+        self.broker.send_message(legacy_message, True)
+        expected = [
+            {
+                "type": "change-packages-result",
+                "operation-id": 99,
+                "result-code": 123,
+            },
+        ]
+        self.assertMessages(self.mstore.get_pending_messages(), expected)
+        self.assertTrue(self.exchanger.is_urgent())
+
     def test_is_pending(self):
         """
         The L{BrokerServer.is_pending} method indicates if a message with

--- a/landscape/client/broker/transport.py
+++ b/landscape/client/broker/transport.py
@@ -1,12 +1,11 @@
 """Low-level server communication."""
-from dataclasses import asdict
 import uuid
+from dataclasses import asdict
 from typing import Optional
 from typing import Union
 
 from landscape import SERVER_API
 from landscape.client.exchange import exchange_messages
-from landscape.lib.compat import unicode
 
 
 class HTTPTransport:
@@ -117,7 +116,7 @@ class FakeTransport:
 
         result = {
             "next-expected-sequence": self.next_expected_sequence,
-            "next-exchange-token": unicode(uuid.uuid4()),
+            "next-exchange-token": str(uuid.uuid4()),
             "messages": response,
         }
         result.update(self.extra)

--- a/landscape/client/configuration.py
+++ b/landscape/client/configuration.py
@@ -28,7 +28,6 @@ from landscape.client.serviceconfig import ServiceConfigException
 from landscape.lib import base64
 from landscape.lib.bootstrap import BootstrapDirectory
 from landscape.lib.bootstrap import BootstrapList
-from landscape.lib.compat import input
 from landscape.lib.fetch import fetch
 from landscape.lib.fetch import FetchError
 from landscape.lib.fs import create_binary_file

--- a/landscape/client/configuration.py
+++ b/landscape/client/configuration.py
@@ -3,6 +3,7 @@
 This module, and specifically L{LandscapeSetupScript}, implements the support
 for the C{landscape-config} script.
 """
+import base64
 import getpass
 import io
 import logging
@@ -25,7 +26,6 @@ from landscape.client.registration import register
 from landscape.client.registration import RegistrationException
 from landscape.client.serviceconfig import ServiceConfig
 from landscape.client.serviceconfig import ServiceConfigException
-from landscape.lib import base64
 from landscape.lib.bootstrap import BootstrapDirectory
 from landscape.lib.bootstrap import BootstrapList
 from landscape.lib.fetch import fetch

--- a/landscape/client/manager/keystonetoken.py
+++ b/landscape/client/manager/keystonetoken.py
@@ -1,12 +1,12 @@
 import logging
 import os
+from configparser import ConfigParser
+from configparser import NoOptionError
 
 from landscape.client import GROUP
 from landscape.client import USER
 from landscape.client.monitor.plugin import DataWatcher
 from landscape.lib.compat import _PY3
-from landscape.lib.compat import ConfigParser
-from landscape.lib.compat import NoOptionError
 from landscape.lib.fs import read_binary_file
 from landscape.lib.persist import Persist
 

--- a/landscape/client/manager/keystonetoken.py
+++ b/landscape/client/manager/keystonetoken.py
@@ -6,7 +6,6 @@ from configparser import NoOptionError
 from landscape.client import GROUP
 from landscape.client import USER
 from landscape.client.monitor.plugin import DataWatcher
-from landscape.lib.compat import _PY3
 from landscape.lib.fs import read_binary_file
 from landscape.lib.persist import Persist
 
@@ -61,17 +60,13 @@ class KeystoneToken(DataWatcher):
             return None
 
         config = ConfigParser()
-        if _PY3:
-            # We need to use the surrogateescape error handler as the
-            # admin_token my contain arbitrary bytes. The ConfigParser in
-            # Python 2 on the other hand does not support read_string.
-            config_str = read_binary_file(self._keystone_config_file).decode(
-                "utf-8",
-                "surrogateescape",
-            )
-            config.read_string(config_str)
-        else:
-            config.read(self._keystone_config_file)
+        # We need to use the surrogateescape error handler as the
+        # admin_token my contain arbitrary bytes.
+        config_str = read_binary_file(self._keystone_config_file).decode(
+            "utf-8",
+            "surrogateescape",
+        )
+        config.read_string(config_str)
         try:
             admin_token = config.get("DEFAULT", "admin_token")
         except NoOptionError:
@@ -80,9 +75,7 @@ class KeystoneToken(DataWatcher):
                 f"{self._keystone_config_file}",
             )
             return None
-        # There is no support for surrogateescape in Python 2, but we actually
-        # have bytes in this case anyway.
-        if _PY3:
-            admin_token = admin_token.encode("utf-8", "surrogateescape")
+
+        admin_token = admin_token.encode("utf-8", "surrogateescape")
 
         return admin_token

--- a/landscape/client/monitor/updatemanager.py
+++ b/landscape/client/monitor/updatemanager.py
@@ -1,8 +1,8 @@
 import logging
 import os
+from configparser import ConfigParser
 
 from landscape.client.monitor.plugin import MonitorPlugin
-from landscape.lib.compat import SafeConfigParser
 
 
 class UpdateManager(MonitorPlugin):
@@ -39,7 +39,7 @@ class UpdateManager(MonitorPlugin):
             # There is no config, so we just act as if it's set to 'normal'
             return "normal"
         config_file = open(self.update_manager_filename)
-        parser = SafeConfigParser()
+        parser = ConfigParser()
         parser.read_file(config_file)
         prompt = parser.get("DEFAULT", "Prompt")
         valid_prompts = ["lts", "never", "normal"]

--- a/landscape/client/package/changer.py
+++ b/landscape/client/package/changer.py
@@ -1,3 +1,4 @@
+import base64
 import grp
 import logging
 import os
@@ -27,7 +28,6 @@ from landscape.constants import POLICY_ALLOW_INSTALLS
 from landscape.constants import POLICY_STRICT
 from landscape.constants import SUCCESS_RESULT
 from landscape.constants import UNKNOWN_PACKAGE_DATA_TIMEOUT
-from landscape.lib import base64
 from landscape.lib.config import get_bindir
 from landscape.lib.fs import create_binary_file
 

--- a/landscape/client/package/tests/test_changer.py
+++ b/landscape/client/package/tests/test_changer.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import sys
 import time
@@ -22,7 +23,6 @@ from landscape.client.package.changer import SUCCESS_RESULT
 from landscape.client.package.changer import UNKNOWN_PACKAGE_DATA_TIMEOUT
 from landscape.client.tests.helpers import BrokerServiceHelper
 from landscape.client.tests.helpers import LandscapeTest
-from landscape.lib import base64
 from landscape.lib.apt.package.facade import DependencyError
 from landscape.lib.apt.package.facade import TransactionError
 from landscape.lib.apt.package.store import PackageStore

--- a/landscape/client/tests/helpers.py
+++ b/landscape/client/tests/helpers.py
@@ -67,7 +67,7 @@ class LandscapeTest(
     testing.TwistedTestCase,
     testing.HelperTestCase,
     testing.ConfigTestCase,
-    testing.CompatTestCase,
+    unittest.TestCase,
 ):
     def setUp(self):
         testing.TwistedTestCase.setUp(self)

--- a/landscape/client/tests/subunit.py
+++ b/landscape/client/tests/subunit.py
@@ -20,8 +20,7 @@ import os
 import subprocess
 import sys
 import unittest
-
-from landscape.lib.compat import StringIO
+from io import StringIO
 
 
 def test_suite():

--- a/landscape/client/tests/test_configuration.py
+++ b/landscape/client/tests/test_configuration.py
@@ -1,6 +1,7 @@
 import os
 import textwrap
 import unittest
+from io import StringIO
 from unittest import mock
 
 from twisted.internet.defer import succeed
@@ -31,7 +32,6 @@ from landscape.client.registration import RegistrationInfo
 from landscape.client.serviceconfig import ServiceConfigException
 from landscape.client.tests.helpers import LandscapeTest
 from landscape.lib.compat import ConfigParser
-from landscape.lib.compat import StringIO
 from landscape.lib.fetch import HTTPCodeError
 from landscape.lib.fetch import PyCurlError
 from landscape.lib.fs import read_binary_file

--- a/landscape/client/tests/test_configuration.py
+++ b/landscape/client/tests/test_configuration.py
@@ -1,6 +1,7 @@
 import os
 import textwrap
 import unittest
+from configparser import ConfigParser
 from io import StringIO
 from unittest import mock
 
@@ -31,7 +32,6 @@ from landscape.client.configuration import store_public_key_data
 from landscape.client.registration import RegistrationInfo
 from landscape.client.serviceconfig import ServiceConfigException
 from landscape.client.tests.helpers import LandscapeTest
-from landscape.lib.compat import ConfigParser
 from landscape.lib.fetch import HTTPCodeError
 from landscape.lib.fetch import PyCurlError
 from landscape.lib.fs import read_binary_file

--- a/landscape/client/user/provider.py
+++ b/landscape/client/user/provider.py
@@ -4,8 +4,6 @@ import subprocess
 from grp import struct_group
 from pwd import struct_passwd
 
-from landscape.lib.compat import _PY3
-
 
 class UserManagementError(Exception):
     """Catch all error for problems with User Management."""
@@ -142,15 +140,9 @@ class UserProvider(UserProviderBase):
         directory, path to the user's shell)
         """
         user_data = []
-        # The DictReader takes bytes in Python 2 and unicode in Python 3 so we
-        # have to pass Python 3 specific parameters to open() and do the
-        # decoding for Python 2 later after we have parsed the rows. We have to
-        # explicitly indicate the encoding as we cannot rely on the system
-        # default encoding.
-        if _PY3:
-            open_params = dict(encoding="utf-8", errors="replace")
-        else:
-            open_params = dict()
+        # We have to explicitly indicate the encoding as we cannot rely on
+        # the system default encoding.
+        open_params = dict(encoding="utf-8", errors="replace")
         with open(self._passwd_file, "r", **open_params) as passwd_file:
             reader = csv.DictReader(
                 passwd_file,
@@ -167,8 +159,7 @@ class UserProvider(UserProviderBase):
                 ].startswith("-"):
                     continue
                 gecos = row["gecos"]
-                if not _PY3 and gecos is not None:
-                    gecos = gecos.decode("utf-8", "replace")
+
                 try:
                     user_data.append(
                         (

--- a/landscape/client/user/provider.py
+++ b/landscape/client/user/provider.py
@@ -142,8 +142,12 @@ class UserProvider(UserProviderBase):
         user_data = []
         # We have to explicitly indicate the encoding as we cannot rely on
         # the system default encoding.
-        open_params = dict(encoding="utf-8", errors="replace")
-        with open(self._passwd_file, "r", **open_params) as passwd_file:
+        with open(
+            self._passwd_file,
+            "r",
+            encoding="utf-8",
+            errors="replace",
+        ) as passwd_file:
             reader = csv.DictReader(
                 passwd_file,
                 fieldnames=self.passwd_fields,

--- a/landscape/lib/apt/package/facade.py
+++ b/landscape/lib/apt/package/facade.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import time
 from collections.abc import Container
+from io import StringIO
 from operator import attrgetter
 
 import apt
@@ -17,7 +18,6 @@ from apt.progress.text import AcquireProgress
 from aptsources.sourceslist import SourcesList
 
 from .skeleton import build_skeleton_apt
-from landscape.lib.compat import StringIO
 from landscape.lib.fs import append_text_file
 from landscape.lib.fs import create_text_file
 from landscape.lib.fs import read_binary_file

--- a/landscape/lib/apt/package/skeleton.py
+++ b/landscape/lib/apt/package/skeleton.py
@@ -1,7 +1,6 @@
 import apt
 
 from landscape.lib.compat import _PY3
-from landscape.lib.compat import unicode
 from landscape.lib.hashlib import sha1
 
 
@@ -146,7 +145,7 @@ def build_skeleton_apt(version, with_info=False, with_unicode=False):
     """
     name, version_string = version.package.name, version.version
     if with_unicode:
-        name, version_string = unicode(name), unicode(version_string)
+        name, version_string = str(name), str(version_string)
     skeleton = PackageSkeleton(DEB_PACKAGE, name, version_string)
     relations = set()
 
@@ -202,6 +201,6 @@ def build_skeleton_apt(version, with_info=False, with_unicode=False):
             skeleton.summary = skeleton.summary.decode("utf-8")
             # Avoid double-decoding package descriptions in build_skeleton_apt,
             # which causes an error with newer python-apt (Xenial onwards)
-            if not isinstance(skeleton.description, unicode):
+            if not isinstance(skeleton.description, str):
                 skeleton.description = skeleton.description.decode("utf-8")
     return skeleton

--- a/landscape/lib/apt/package/skeleton.py
+++ b/landscape/lib/apt/package/skeleton.py
@@ -1,6 +1,5 @@
 import apt
 
-from landscape.lib.compat import _PY3
 from landscape.lib.hashlib import sha1
 
 
@@ -196,11 +195,4 @@ def build_skeleton_apt(version, with_info=False, with_unicode=False):
         skeleton.size = version.size
         if version.installed_size > 0:
             skeleton.installed_size = version.installed_size
-        if with_unicode and not _PY3:
-            skeleton.section = skeleton.section.decode("utf-8")
-            skeleton.summary = skeleton.summary.decode("utf-8")
-            # Avoid double-decoding package descriptions in build_skeleton_apt,
-            # which causes an error with newer python-apt (Xenial onwards)
-            if not isinstance(skeleton.description, str):
-                skeleton.description = skeleton.description.decode("utf-8")
     return skeleton

--- a/landscape/lib/apt/package/testing.py
+++ b/landscape/lib/apt/package/testing.py
@@ -1,10 +1,10 @@
+import base64
 import os
 import time
 
 import apt_inst
 import apt_pkg
 
-from landscape.lib import base64
 from landscape.lib.apt.package.facade import AptFacade
 from landscape.lib.fs import append_binary_file
 from landscape.lib.fs import create_binary_file

--- a/landscape/lib/base64.py
+++ b/landscape/lib/base64.py
@@ -1,6 +1,1 @@
-from landscape.lib.compat import _PY3
-
-if _PY3:
-    from base64 import decodebytes  # noqa
-else:
-    from base64 import decodestring as decodebytes  # noqa
+from base64 import decodebytes  # noqa

--- a/landscape/lib/base64.py
+++ b/landscape/lib/base64.py
@@ -1,1 +1,0 @@
-from base64 import decodebytes  # noqa

--- a/landscape/lib/bpickle.py
+++ b/landscape/lib/bpickle.py
@@ -31,12 +31,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 This file is modified from the original to work with python3, but should be
 wire compatible and behave the same way (bugs notwithstanding).
 """
-from typing import Dict
 from typing import Callable
+from typing import Dict
 
 from landscape.lib.compat import _PY3
-from landscape.lib.compat import long
-from landscape.lib.compat import unicode
 
 dumps_table: Dict[type, Callable] = {}
 loads_table: Dict[bytes, Callable] = {}
@@ -217,19 +215,9 @@ loads_table.update(
 )
 
 
-if bytes is str:
-    # Python 2.x: We need to map internal unicode strings to UTF-8
-    # encoded strings, and longs to ints.
-    dumps_table.update(
-        {
-            unicode: dumps_unicode,  # noqa
-            long: dumps_int,  # noqa
-        },
-    )
-else:
-    # Python 3.x: We need to map internal strings to UTF-8 encoded strings.
-    dumps_table.update(
-        {
-            str: dumps_unicode,
-        },
-    )
+# Python 3.x: We need to map internal strings to UTF-8 encoded strings.
+dumps_table.update(
+    {
+        str: dumps_unicode,
+    },
+)

--- a/landscape/lib/bpickle.py
+++ b/landscape/lib/bpickle.py
@@ -34,8 +34,6 @@ wire compatible and behave the same way (bugs notwithstanding).
 from typing import Callable
 from typing import Dict
 
-from landscape.lib.compat import _PY3
-
 dumps_table: Dict[type, Callable] = {}
 loads_table: Dict[bytes, Callable] = {}
 
@@ -173,7 +171,7 @@ def loads_dict(bytestring, pos, _lt=loads_table, as_is=False):
     while bytestring[pos : pos + 1] != b";":
         key, pos = _lt[bytestring[pos : pos + 1]](bytestring, pos, as_is=as_is)
         val, pos = _lt[bytestring[pos : pos + 1]](bytestring, pos, as_is=as_is)
-        if _PY3 and not as_is and isinstance(key, bytes):
+        if not as_is and isinstance(key, bytes):
             # Although the wire format of dictionary keys is ASCII bytes, the
             # code actually expects them to be strings, so we convert them
             # here.

--- a/landscape/lib/compat.py
+++ b/landscape/lib/compat.py
@@ -3,9 +3,5 @@
 
 _PY3 = True
 
-from configparser import ConfigParser, NoOptionError
-
-SafeConfigParser = ConfigParser
-
 unicode = str
 long = int

--- a/landscape/lib/compat.py
+++ b/landscape/lib/compat.py
@@ -1,4 +1,0 @@
-# flake8: noqa
-# TiCS: disabled
-
-_PY3 = True

--- a/landscape/lib/compat.py
+++ b/landscape/lib/compat.py
@@ -10,7 +10,5 @@ SafeConfigParser = ConfigParser
 
 import _thread as thread
 
-from builtins import input
-
 unicode = str
 long = int

--- a/landscape/lib/compat.py
+++ b/landscape/lib/compat.py
@@ -3,7 +3,6 @@
 
 _PY3 = True
 
-import pickle as cPickle
 from configparser import ConfigParser, NoOptionError
 
 SafeConfigParser = ConfigParser

--- a/landscape/lib/compat.py
+++ b/landscape/lib/compat.py
@@ -2,6 +2,3 @@
 # TiCS: disabled
 
 _PY3 = True
-
-unicode = str
-long = int

--- a/landscape/lib/compat.py
+++ b/landscape/lib/compat.py
@@ -10,9 +10,6 @@ SafeConfigParser = ConfigParser
 
 import _thread as thread
 
-from io import StringIO
-
-stringio = cstringio = StringIO
 from builtins import input
 
 unicode = str

--- a/landscape/lib/compat.py
+++ b/landscape/lib/compat.py
@@ -8,7 +8,5 @@ from configparser import ConfigParser, NoOptionError
 
 SafeConfigParser = ConfigParser
 
-import _thread as thread
-
 unicode = str
 long = int

--- a/landscape/lib/disk.py
+++ b/landscape/lib/disk.py
@@ -2,8 +2,6 @@ import codecs
 import os
 import re
 
-from landscape.lib.compat import _PY3
-
 
 # List of filesystem types authorized when generating disk use statistics.
 STABLE_FILESYSTEMS = frozenset(
@@ -56,10 +54,7 @@ def get_mount_info(
     for line in open(mounts_file):
         try:
             device, mount_point, filesystem = line.split()[:3]
-            if _PY3:
-                mount_point = codecs.decode(mount_point, "unicode_escape")
-            else:
-                mount_point = codecs.decode(mount_point, "string_escape")
+            mount_point = codecs.decode(mount_point, "unicode_escape")
         except ValueError:
             continue
         if (

--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -11,7 +11,6 @@ import struct
 import netifaces
 
 from landscape.lib.compat import _PY3
-from landscape.lib.compat import long
 
 __all__ = ["get_active_device_info", "get_network_traffic"]
 
@@ -252,7 +251,7 @@ def get_network_traffic(source_file="/proc/net/dev"):
             continue
         device, data = line.split(":")
         device = device.strip()
-        devices[device] = dict(zip(columns, map(long, data.split())))
+        devices[device] = dict(zip(columns, map(int, data.split())))
     return devices
 
 

--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -10,8 +10,6 @@ import struct
 
 import netifaces
 
-from landscape.lib.compat import _PY3
-
 __all__ = ["get_active_device_info", "get_network_traffic"]
 
 
@@ -299,10 +297,7 @@ def get_network_interface_speed(sock, interface_name):
     speed = -1
     try:
         fcntl.ioctl(sock, SIOCETHTOOL, packed)  # Status ioctl() call
-        if _PY3:
-            res = status_cmd.tobytes()
-        else:
-            res = status_cmd.tostring()
+        res = status_cmd.tobytes()
         speed, duplex = struct.unpack("12xHB28x", res)
     except (IOError, OSError) as e:
         if e.errno == errno.EPERM:

--- a/landscape/lib/persist.py
+++ b/landscape/lib/persist.py
@@ -622,9 +622,9 @@ class Backend:
 
 class PickleBackend(Backend):
     def __init__(self):
-        from landscape.lib.compat import cPickle
+        import pickle
 
-        self._pickle = cPickle
+        self._pickle = pickle
 
     def new(self):
         return {}

--- a/landscape/lib/testing.py
+++ b/landscape/lib/testing.py
@@ -18,16 +18,9 @@ from twisted.internet.error import ConnectError
 from twisted.python.failure import Failure
 from twisted.trial.unittest import TestCase
 
-from landscape.lib.compat import _PY3
 from landscape.lib.config import BaseConfiguration
 from landscape.lib.reactor import EventHandlingReactorMixin
 from landscape.lib.sysstats import LoginInfo
-
-
-class CompatTestCase(unittest.TestCase):
-
-    if not _PY3:
-        assertCountEqual = TestCase.assertItemsEqual  # noqa: N815
 
 
 class HelperTestCase(unittest.TestCase):
@@ -393,8 +386,6 @@ class StandardIOHelper:
         test_case.old_stdin = sys.stdin
         test_case.stdout = sys.stdout = StringIO()
         test_case.stdin = sys.stdin = StringIO()
-        if not _PY3:
-            test_case.stdin.encoding = "UTF-8"
 
     def tear_down(self, test_case):
         sys.stdout = test_case.old_stdout

--- a/landscape/lib/testing.py
+++ b/landscape/lib/testing.py
@@ -7,6 +7,7 @@ import struct
 import sys
 import tempfile
 import unittest
+from io import StringIO
 from logging import ERROR
 from logging import Formatter
 from logging import Handler
@@ -18,8 +19,6 @@ from twisted.trial.unittest import TestCase
 
 from landscape.lib.compat import _PY3
 from landscape.lib.compat import ConfigParser
-from landscape.lib.compat import cstringio
-from landscape.lib.compat import stringio
 from landscape.lib.config import BaseConfiguration
 from landscape.lib.reactor import EventHandlingReactorMixin
 from landscape.lib.sysstats import LoginInfo
@@ -175,11 +174,11 @@ class ConfigTestCase(FSTestCase):
         and comments may be different but the actual parameters and sections
         must be the same.
         """
-        first_fp = cstringio(first)
+        first_fp = StringIO(first)
         first_parser = ConfigParser()
         first_parser.read_file(first_fp)
 
-        second_fp = cstringio(second)
+        second_fp = StringIO(second)
         second_parser = ConfigParser()
         second_parser.read_file(second_fp)
 
@@ -301,7 +300,7 @@ class LogKeeperHelper:
         self.error_handler = ErrorHandler()
         test_case.log_helper = self
         test_case.logger = logger = logging.getLogger()
-        test_case.logfile = cstringio()
+        test_case.logfile = StringIO()
         handler = logging.StreamHandler(test_case.logfile)
         format = "%(levelname)8s: %(message)s"
         handler.setFormatter(logging.Formatter(format))
@@ -362,7 +361,7 @@ class MockPopen:
     def __init__(self, output, return_codes=None, err_out=""):
         self.output = output
         self.err_out = err_out
-        self.stdout = cstringio(output)
+        self.stdout = StringIO(output)
         self.popen_inputs = []
         self.return_codes = return_codes
         self.received_input = None
@@ -392,8 +391,8 @@ class StandardIOHelper:
     def set_up(self, test_case):
         test_case.old_stdout = sys.stdout
         test_case.old_stdin = sys.stdin
-        test_case.stdout = sys.stdout = stringio()
-        test_case.stdin = sys.stdin = stringio()
+        test_case.stdout = sys.stdout = StringIO()
+        test_case.stdin = sys.stdin = StringIO()
         if not _PY3:
             test_case.stdin.encoding = "UTF-8"
 

--- a/landscape/lib/testing.py
+++ b/landscape/lib/testing.py
@@ -7,6 +7,7 @@ import struct
 import sys
 import tempfile
 import unittest
+from configparser import ConfigParser
 from io import StringIO
 from logging import ERROR
 from logging import Formatter
@@ -18,7 +19,6 @@ from twisted.python.failure import Failure
 from twisted.trial.unittest import TestCase
 
 from landscape.lib.compat import _PY3
-from landscape.lib.compat import ConfigParser
 from landscape.lib.config import BaseConfiguration
 from landscape.lib.reactor import EventHandlingReactorMixin
 from landscape.lib.sysstats import LoginInfo

--- a/landscape/lib/tests/test_reactor.py
+++ b/landscape/lib/tests/test_reactor.py
@@ -1,9 +1,9 @@
+import _thread as thread
 import time
 import types
 import unittest
 
 from landscape.lib import testing
-from landscape.lib.compat import thread
 from landscape.lib.reactor import EventHandlingReactor
 from landscape.lib.testing import FakeReactor
 

--- a/landscape/lib/tests/test_sysstats.py
+++ b/landscape/lib/tests/test_sysstats.py
@@ -1,7 +1,8 @@
 import os
 import re
 from datetime import datetime
-from unittest import TestCase, mock
+from unittest import mock
+from unittest import TestCase
 
 from landscape.lib import testing
 from landscape.lib.sysstats import BootTimes
@@ -165,7 +166,7 @@ class GetProcfsThermalZonesTest(ProcfsThermalZoneTest):
     @mock.patch("glob.glob")
     @mock.patch("os.path.isdir")
     def test_default_thermal_zone_path(self, isdir_mock, glob_mock):
-        isdir_mock.side_effect = (lambda dir: dir == "/proc/acpi/thermal_zone")
+        isdir_mock.side_effect = lambda dir: dir == "/proc/acpi/thermal_zone"
         thermal_zones = list(get_thermal_zones(None))
         self.assertEqual(thermal_zones, [])
         glob_mock.assert_called_with("/proc/acpi/thermal_zone/*/temperature")
@@ -232,7 +233,7 @@ class GetProcfsThermalZonesTest(ProcfsThermalZoneTest):
         self.assertEqual(thermal_zones[0].temperature_unit, None)
 
 
-class SysfsThermalZoneTest(BaseTestCase):
+class SysfsThermalZoneTest(testing.TwistedTestCase, testing.FSTestCase):
     def setUp(self):
         super().setUp()
         self.base_path = self.makeDir()
@@ -254,7 +255,7 @@ class GetSysfsThermalZonesTest(SysfsThermalZoneTest):
     @mock.patch("glob.glob")
     @mock.patch("os.path.isdir")
     def test_default_thermal_zone_path(self, isdir_mock, glob_mock):
-        isdir_mock.side_effect = (lambda dir: dir == "/sys/class/thermal")
+        isdir_mock.side_effect = lambda dir: dir == "/sys/class/thermal"
         thermal_zones = list(get_thermal_zones(None))
         self.assertEqual(thermal_zones, [])
         glob_mock.assert_called_with("/sys/class/thermal/*/temp")
@@ -347,7 +348,7 @@ class GetHwmonThermalZonesTest(HwmonThermalZoneTest):
     @mock.patch("glob.glob")
     @mock.patch("os.path.isdir")
     def test_default_thermal_zone_path(self, isdir_mock, glob_mock):
-        isdir_mock.side_effect = (lambda dir: dir == "/sys/class/hwmon")
+        isdir_mock.side_effect = lambda dir: dir == "/sys/class/hwmon"
         thermal_zones = list(get_thermal_zones(None))
         self.assertEqual(thermal_zones, [])
         glob_mock.assert_called_with("/sys/class/hwmon/*/temp*_input")

--- a/landscape/lib/user.py
+++ b/landscape/lib/user.py
@@ -1,9 +1,6 @@
 import os.path
 import pwd
 
-from landscape.lib.compat import _PY3
-from landscape.lib.encoding import encode_if_needed
-
 
 class UnknownUserError(Exception):
     pass
@@ -14,10 +11,6 @@ def get_user_info(username=None):
     gid = None
     path = None
     if username is not None:
-        if _PY3:
-            username_str = username
-        else:
-            username_str = encode_if_needed(username)
         try:
             # XXX: We have a situation with the system default FS encoding with
             # Python 3 here: We have to pass a string to pwd.getpwnam(), but if
@@ -29,7 +22,7 @@ def get_user_info(username=None):
             # circumstances. Alternatively, a different way of parsing
             # /etc/passwd would have to be implemented. A simple
             # locale.setlocale() to use UTF-8 was not successful.
-            info = pwd.getpwnam(username_str)
+            info = pwd.getpwnam(username)
         except (KeyError, UnicodeEncodeError):
             raise UnknownUserError(f"Unknown user '{username}'")
         uid = info.pw_uid

--- a/landscape/sysinfo/tests/test_sysinfo.py
+++ b/landscape/sysinfo/tests/test_sysinfo.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from io import StringIO
 from logging import getLogger
 from logging import StreamHandler
 from unittest import mock
@@ -8,7 +9,6 @@ from twisted.internet.defer import Deferred
 from twisted.internet.defer import fail
 from twisted.internet.defer import succeed
 
-from landscape.lib.compat import StringIO
 from landscape.lib.plugin import PluginRegistry
 from landscape.lib.testing import HelperTestCase
 from landscape.sysinfo.sysinfo import format_sysinfo


### PR DESCRIPTION
This PR removes some code that only exists to support compatibility for both Python2 and Python3 environments. As Python2 is no longer supported, this code is not needed.

Note: after these changes, code supporting Python2 still remains and should be considered for removal. 