### PR TITLE
fix: remove deprecated use of `unittest.makeSuite` to get tests passing on >=py312

### DIFF
--- a/landscape/lib/tests/test_sequenceranges.py
+++ b/landscape/lib/tests/test_sequenceranges.py
@@ -297,11 +297,21 @@ class RemoveFromRangesTest(unittest.TestCase):
 def test_suite():
     return unittest.TestSuite(
         (
-            unittest.makeSuite(SequenceToRangesTest),
-            unittest.makeSuite(RangesToSequenceTest),
-            unittest.makeSuite(SequenceRangesTest),
-            unittest.makeSuite(FindRangesIndexTest),
-            unittest.makeSuite(AddToRangesTest),
-            unittest.makeSuite(RemoveFromRangesTest),
+            unittest.defaultTestLoader.loadTestsFromTestCase(
+                SequenceToRangesTest,
+            ),
+            unittest.defaultTestLoader.loadTestsFromTestCase(
+                RangesToSequenceTest,
+            ),
+            unittest.defaultTestLoader.loadTestsFromTestCase(
+                SequenceRangesTest,
+            ),
+            unittest.defaultTestLoader.loadTestsFromTestCase(
+                FindRangesIndexTest,
+            ),
+            unittest.defaultTestLoader.loadTestsFromTestCase(AddToRangesTest),
+            unittest.defaultTestLoader.loadTestsFromTestCase(
+                RemoveFromRangesTest,
+            ),
         ),
     )


### PR DESCRIPTION
You can validate this fix pretty easily:

1. create a plucky LXD container:
```bash
dev_lxc create plucky --config ./.dev-lxc/config.yaml
```
3. run the tests:
```bash
make check
```

Without this change, they will fail with:
```
builtins.AttributeError: module 'unittest' has no attribute 'makeSuite'
```

With this change, they should all pass (or skip).