### PR TITLE
ci: check if CLA is signed on each PR

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -1,0 +1,13 @@
+name: Check if CLA is signed
+on:
+    pull_request:
+
+jobs:
+  cla-check:
+    name: Check if CLA is signed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v2
+        with:
+          accept-existing-contributors: true

--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -9,5 +9,3 @@ jobs:
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v2
-        with:
-          accept-existing-contributors: true


### PR DESCRIPTION
Compare with, e.g., this successful run of the same action in a different repo: https://github.com/canonical/landscape-documentation/actions/runs/14109971121/job/39525837115