### PR TITLE
fix: .list and .sources files are restored when a repository profile is disassociated from a noble (or later) instance

### DIFF
--- a/landscape/client/manager/aptsources.py
+++ b/landscape/client/manager/aptsources.py
@@ -1,5 +1,6 @@
 import glob
 import grp
+import logging
 import os
 import pwd
 import shutil
@@ -162,6 +163,12 @@ class AptSources(ManagerPlugin):
                     for filename in filenames:
                         restored_filename = filename.removesuffix(".save")
                         shutil.move(filename, restored_filename)
+
+            # Delete old profile source files prefixed with `landscape-`
+            landscape_profile_filenames = glob.glob(os.path.join(self.SOURCES_LIST_D, "landscape-*.list"))
+
+            for profile_filename in landscape_profile_filenames:
+                os.remove(profile_filename)
 
         for source in sources:
             filename = os.path.join(

--- a/landscape/client/manager/aptsources.py
+++ b/landscape/client/manager/aptsources.py
@@ -120,14 +120,6 @@ class AptSources(ManagerPlugin):
             True,
         )
 
-        if manage_sources_list_d not in FALSE_VALUES:
-            for pattern in self.SOURCES_LIST_D_FILE_PATTERNS:
-                filenames = glob.glob(
-                    os.path.join(self.SOURCES_LIST_D, pattern)
-                )
-                for filename in filenames:
-                    shutil.move(filename, f"{filename}.save")
-
         if sources:
             fd, path = tempfile.mkstemp()
             os.close(fd)
@@ -150,6 +142,13 @@ class AptSources(ManagerPlugin):
                 original_stat.st_gid,
             )
 
+            if manage_sources_list_d not in FALSE_VALUES:
+                for pattern in self.SOURCES_LIST_D_FILE_PATTERNS:
+                    filenames = glob.glob(
+                        os.path.join(self.SOURCES_LIST_D, pattern)
+                    )
+                    for filename in filenames:
+                        shutil.move(filename, f"{filename}.save")
         else:
             # Re-instate original sources
             if os.path.isfile(saved_sources):

--- a/landscape/client/manager/aptsources.py
+++ b/landscape/client/manager/aptsources.py
@@ -1,6 +1,5 @@
 import glob
 import grp
-import logging
 import os
 import pwd
 import shutil
@@ -165,7 +164,9 @@ class AptSources(ManagerPlugin):
                         shutil.move(filename, restored_filename)
 
             # Delete old profile source files prefixed with `landscape-`
-            landscape_profile_filenames = glob.glob(os.path.join(self.SOURCES_LIST_D, "landscape-*.list"))
+            landscape_profile_filenames = glob.glob(
+                os.path.join(self.SOURCES_LIST_D, "landscape-*.list")
+            )
 
             for profile_filename in landscape_profile_filenames:
                 os.remove(profile_filename)

--- a/landscape/client/manager/aptsources.py
+++ b/landscape/client/manager/aptsources.py
@@ -163,13 +163,13 @@ class AptSources(ManagerPlugin):
                         restored_filename = filename.removesuffix(".save")
                         shutil.move(filename, restored_filename)
 
-            # Delete old profile source files prefixed with `landscape-`
-            landscape_profile_filenames = glob.glob(
+            # Delete Landscape source files prefixed with `landscape-`
+            landscape_source_filenames = glob.glob(
                 os.path.join(self.SOURCES_LIST_D, "landscape-*.list")
             )
 
-            for profile_filename in landscape_profile_filenames:
-                os.remove(profile_filename)
+            for source_filename in landscape_source_filenames:
+                os.remove(source_filename)
 
         for source in sources:
             filename = os.path.join(

--- a/landscape/client/manager/tests/test_aptsources.py
+++ b/landscape/client/manager/tests/test_aptsources.py
@@ -241,32 +241,60 @@ class AptSourcesTests(LandscapeTest):
         profile source files in `/etc/apt/sources.list.d` prefixed with
         `landscape-` will be removed.
         """
+        first_source_name = "ginger"
+
         self.manager.dispatch_message(
             {
                 "type": "apt-sources-replace",
-                "sources": [{"name": "bla", "content": b""}],
+                "sources": [{"name": first_source_name, "content": b""}],
                 "gpg-keys": [],
                 "operation-id": 1,
             },
         )
 
-        saved_sources_path = os.path.join(
+        first_sources_path = os.path.join(
             self.sourceslist.SOURCES_LIST_D,
-            "landscape-bla.list",
+            f"landscape-{first_source_name}.list",
         )
 
-        self.assertTrue(os.path.exists(saved_sources_path))
+        self.assertTrue(os.path.exists(first_sources_path))
+
+        second_source_name = "ace rothstein"
+
+        self.manager.dispatch_message(
+            {
+                "type": "apt-sources-replace",
+                "sources": [{"name": second_source_name, "content": b""}],
+                "gpg-keys": [],
+                "operation-id": 2,
+            },
+        )
+
+        second_sources_path = os.path.join(
+            self.sourceslist.SOURCES_LIST_D,
+            f"landscape-{second_source_name}.list",
+        )
+
+        self.assertTrue(os.path.exists(f"{first_sources_path}.save"))
+
+        self.assertTrue(os.path.exists(second_sources_path))
 
         self.manager.dispatch_message(
             {
                 "type": "apt-sources-replace",
                 "sources": [],
                 "gpg-keys": [],
-                "operation-id": 2,
+                "operation-id": 3,
             },
         )
 
-        self.assertFalse(os.path.exists(saved_sources_path))
+        self.assertFalse(
+            os.path.exists(first_sources_path)
+        )
+
+        self.assertFalse(
+            os.path.exists(second_sources_path)
+        )
 
     def test_sources_list_permissions(self):
         """

--- a/landscape/client/manager/tests/test_aptsources.py
+++ b/landscape/client/manager/tests/test_aptsources.py
@@ -235,6 +235,39 @@ class AptSourcesTests(LandscapeTest):
             os.path.exists(f"{FILE_2_SOURCES}.save"),
         )
 
+    def test_restore_sources_list_d_removes_old_profile_files(self):
+        """
+        When getting a repository message without sources, old
+        profile source files in `/etc/apt/sources.list.d` prefixed with
+        `landscape-` will be removed.
+        """
+        self.manager.dispatch_message(
+            {
+                "type": "apt-sources-replace",
+                "sources": [{"name": "bla", "content": b""}],
+                "gpg-keys": [],
+                "operation-id": 1,
+            },
+        )
+
+        saved_sources_path = os.path.join(
+            self.sourceslist.SOURCES_LIST_D,
+            "landscape-bla.list",
+        )
+
+        self.assertTrue(os.path.exists(saved_sources_path))
+
+        self.manager.dispatch_message(
+            {
+                "type": "apt-sources-replace",
+                "sources": [],
+                "gpg-keys": [],
+                "operation-id": 2,
+            },
+        )
+
+        self.assertFalse(os.path.exists(saved_sources_path))
+
     def test_sources_list_permissions(self):
         """
         When getting a repository message, L{AptSources} keeps sources.list
@@ -356,10 +389,14 @@ class AptSourcesTests(LandscapeTest):
         self.manager.dispatch_message(
             {
                 "type": "apt-sources-replace",
-                "sources": [],
+                "sources": [{"name": "bla", "content": b""}],
                 "gpg-keys": [],
                 "operation-id": 1,
             },
+        )
+
+        self.assertTrue(
+            os.path.exists(self.sourceslist.SOURCES_LIST),
         )
 
         self.assertFalse(

--- a/landscape/client/manager/tests/test_aptsources.py
+++ b/landscape/client/manager/tests/test_aptsources.py
@@ -189,7 +189,6 @@ class AptSourcesTests(LandscapeTest):
         ) as source2:
             source2.write("ok\n")
 
-
         self.manager.dispatch_message(
             {
                 "type": "apt-sources-replace",

--- a/landscape/client/manager/tests/test_aptsources.py
+++ b/landscape/client/manager/tests/test_aptsources.py
@@ -238,7 +238,7 @@ class AptSourcesTests(LandscapeTest):
     def test_restore_sources_list_d_removes_old_profile_files(self):
         """
         When getting a repository message without sources, old
-        profile source files in `/etc/apt/sources.list.d` prefixed with
+        source files in `/etc/apt/sources.list.d` prefixed with
         `landscape-` will be removed.
         """
         first_source_name = "ginger"
@@ -288,13 +288,9 @@ class AptSourcesTests(LandscapeTest):
             },
         )
 
-        self.assertFalse(
-            os.path.exists(first_sources_path)
-        )
+        self.assertFalse(os.path.exists(first_sources_path))
 
-        self.assertFalse(
-            os.path.exists(second_sources_path)
-        )
+        self.assertFalse(os.path.exists(second_sources_path))
 
     def test_sources_list_permissions(self):
         """

--- a/landscape/client/manager/tests/test_aptsources.py
+++ b/landscape/client/manager/tests/test_aptsources.py
@@ -165,6 +165,77 @@ class AptSourcesTests(LandscapeTest):
         with open(self.sourceslist.SOURCES_LIST) as sources:
             self.assertEqual("original content\n", sources.read())
 
+    def test_restore_sources_list_d(self):
+        """
+        When getting a repository message without sources, AptSources
+        restores the previous files in sources.list.d.
+        """
+        FILE_1_LIST = os.path.join(
+            self.sourceslist.SOURCES_LIST_D, "file1.list"
+        )
+
+        FILE_2_SOURCES = os.path.join(
+            self.sourceslist.SOURCES_LIST_D, "file2.sources"
+        )
+        with open(
+            FILE_1_LIST,
+            "w",
+        ) as source1:
+            source1.write("ok\n")
+
+        with open(
+            FILE_2_SOURCES,
+            "w",
+        ) as source2:
+            source2.write("ok\n")
+
+
+        self.manager.dispatch_message(
+            {
+                "type": "apt-sources-replace",
+                "sources": [{"name": "bla", "content": b""}],
+                "gpg-keys": [],
+                "operation-id": 1,
+            },
+        )
+
+        self.assertFalse(
+            os.path.exists(FILE_1_LIST),
+        )
+
+        self.assertFalse(os.path.exists(FILE_2_SOURCES))
+
+        self.assertTrue(
+            os.path.exists(f"{FILE_1_LIST}.save"),
+        )
+
+        self.assertTrue(
+            os.path.exists(f"{FILE_2_SOURCES}.save"),
+        )
+
+        self.manager.dispatch_message(
+            {
+                "type": "apt-sources-replace",
+                "sources": [],
+                "gpg-keys": [],
+                "operation-id": 2,
+            },
+        )
+
+        self.assertTrue(
+            os.path.exists(FILE_1_LIST),
+        )
+
+        self.assertTrue(os.path.exists(FILE_2_SOURCES))
+
+        self.assertFalse(
+            os.path.exists(f"{FILE_1_LIST}.save"),
+        )
+
+        self.assertFalse(
+            os.path.exists(f"{FILE_2_SOURCES}.save"),
+        )
+
     def test_sources_list_permissions(self):
         """
         When getting a repository message, L{AptSources} keeps sources.list


### PR DESCRIPTION
https://bugs.launchpad.net/landscape-client/+bug/2087852

---

The reason this is only "for noble" is because it uses DEB822-style sources in `/etc/sources.list.d` instead of `sources.list` like jammy and previous. 

## Manual testing

Register a Landscape Client noble instance to Landscape Server.

In the client's `/etc/apt/sources.list.d`:

```bash
touch hello.list hello.sources
```

Create a repository profile, and associate it with the client. The easiest way is through the UI. Wait for the activity to run and in the client's `sources.list.d`, you should see:

```
hello.list.save 
hello.sources.save 
ubuntu.sources.save 
landscape-<profile-name>.list
```

Now, delete the repository profile or disassociate it with the instance, and wait for the activity to run. Now, check on the client's `sources.list.d` You should see that the sources have been restored, and the profile has been deleted:

```
hello.list
hello.sources 
ubuntu.sources
```

Also, it is worth testing the behavior when multiple repository profiles are applied. The most-recently-applied one will take precedent over any others, and when all profiles are removed/disassociated, all `landscape-*.list` profile source files in `/etc/apt/sources.list.d` will be removed and the original sources are restored.