### PR TITLE
fix: ensure usgmanager plugin runs in deferred

### DIFF
--- a/landscape/client/manager/tests/test_usgmanager.py
+++ b/landscape/client/manager/tests/test_usgmanager.py
@@ -74,7 +74,7 @@ class UsgManagerTests(LandscapeTest):
             self.spawn_mock.assert_called_once_with(
                 mock.ANY,
                 USG_EXECUTABLE_ABS,
-                args=["audit", "cis_level1_workstation"],
+                args=[USG_EXECUTABLE_ABS, "audit", "cis_level1_workstation"],
             )
             which.assert_called_once_with(USG_EXECUTABLE_ABS)
             self.assertEqual(
@@ -179,7 +179,7 @@ class UsgManagerTests(LandscapeTest):
             self.spawn_mock.assert_called_once_with(
                 mock.ANY,
                 USG_EXECUTABLE_ABS,
-                args=["fix", "cis_level1_workstation"],
+                args=[USG_EXECUTABLE_ABS, "fix", "cis_level1_workstation"],
             )
             which.assert_called_once_with(USG_EXECUTABLE_ABS)
             send_message.assert_has_calls(
@@ -241,6 +241,7 @@ class UsgManagerTests(LandscapeTest):
                 mock.ANY,
                 USG_EXECUTABLE_ABS,
                 args=[
+                    USG_EXECUTABLE_ABS,
                     "audit",
                     "cis_level1_workstation",
                     "--tailoring-file",
@@ -289,7 +290,7 @@ class UsgManagerTests(LandscapeTest):
             self.spawn_mock.assert_called_once_with(
                 mock.ANY,
                 USG_EXECUTABLE_ABS,
-                args=["audit", "cis_level1_workstation"],
+                args=[USG_EXECUTABLE_ABS, "audit", "cis_level1_workstation"],
             )
             which.assert_called_once_with(USG_EXECUTABLE_ABS)
             self.assertEqual(
@@ -339,7 +340,7 @@ class UsgManagerTests(LandscapeTest):
             self.spawn_mock.assert_called_once_with(
                 mock.ANY,
                 USG_EXECUTABLE_ABS,
-                args=["audit", "cis_level1_workstation"],
+                args=[USG_EXECUTABLE_ABS, "audit", "cis_level1_workstation"],
             )
             which.assert_called_once_with(USG_EXECUTABLE_ABS)
             self.assertEqual(

--- a/landscape/client/manager/usgmanager.py
+++ b/landscape/client/manager/usgmanager.py
@@ -9,7 +9,7 @@ from typing import Tuple
 from typing import Union
 
 from twisted.internet import reactor
-from twisted.internet.defer import Deferred
+from twisted.internet.defer import Deferred, ensureDeferred
 
 from landscape.client.attachments import save_attachments
 from landscape.client.manager.plugin import FAILED
@@ -51,8 +51,11 @@ class UsgManager(ManagerPlugin):
         super().register(registry)
         registry.register_message(
             "usg",
-            self.handle_usg_message,
+            self._handle_usg_message,
         )
+
+    def _handle_usg_message(self, message):
+        return ensureDeferred(self.handle_usg_message(message))
 
     async def handle_usg_message(self, message: Dict[str, Any]) -> None:
         """Executes usg if we can, then responds to `message`.
@@ -205,7 +208,7 @@ class UsgManager(ManagerPlugin):
 
         :returns: the deferred result of the usg process
         """
-        args = [action, profile]
+        args = [USG_EXECUTABLE_ABS, action, profile]
 
         if tailoring_file is not None:
             args.extend([TAILORING_FILE_PARAM, tailoring_file])


### PR DESCRIPTION
The UsgManager does not seem to be running. Wraps the execution in a deferred. 

Additionally, spawnProcess must be passed the name of the process as the first argument.

```
args is a list of command line arguments to be passed to the process. args[0] should be the name of the process.
```