### PR TITLE
fix: usgmanager should accept only the profile or the tailoring file

### DIFF
--- a/landscape/client/manager/tests/test_usgmanager.py
+++ b/landscape/client/manager/tests/test_usgmanager.py
@@ -232,8 +232,7 @@ class UsgManagerTests(LandscapeTest):
                 {
                     "operation-id": 1,
                     "action": "audit",
-                    "profile": "cis_level1_workstation",
-                    "tailoring-file": (83497, "test-tailoring.xml"),
+                    "tailoring-file": ("test-tailoring.xml", 83497),
                     "run-id": str(uuid.uuid4()),
                 },
             ),
@@ -251,7 +250,6 @@ class UsgManagerTests(LandscapeTest):
                 args=[
                     USG_EXECUTABLE_ABS,
                     "audit",
-                    "cis_level1_workstation",
                     "--tailoring-file",
                     tailoring_file_path,
                 ],
@@ -259,7 +257,7 @@ class UsgManagerTests(LandscapeTest):
 
             save_attachments.assert_called_once_with(
                 self.plugin.registry.config,
-                ((83497, "test-tailoring.xml"),),
+                (("test-tailoring.xml", 83497),),
                 mock.ANY,
             )
 

--- a/landscape/client/manager/usgmanager.py
+++ b/landscape/client/manager/usgmanager.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -65,6 +66,7 @@ class UsgManager(ManagerPlugin):
 
         :message: A message of type "usg".
         """
+        logging.info(str(message))
         opid = message["operation-id"]
         runid = message["run-id"]
 
@@ -76,6 +78,7 @@ class UsgManager(ManagerPlugin):
         profile = message.get("profile")
         tailoring_file = message.get("tailoring-file")
         assert profile is not None or tailoring_file is not None
+        logging.info("message")
 
         try:
             result = await self._usg_operation(
@@ -83,6 +86,7 @@ class UsgManager(ManagerPlugin):
                 profile,
                 tailoring_file,
             )
+            logging.info("usg results ")
             await self._respond(SUCCEEDED, result, opid)
 
             if action == "audit":
@@ -151,7 +155,7 @@ class UsgManager(ManagerPlugin):
         )
         os.makedirs(attachment_dir, mode=0o700, exist_ok=True)
 
-        attachment_path = os.path.join(attachment_dir, str(attachment[1]))
+        attachment_path = os.path.join(attachment_dir, str(attachment[0]))
 
         await save_attachments(
             self.registry.config,

--- a/landscape/client/manager/usgmanager.py
+++ b/landscape/client/manager/usgmanager.py
@@ -73,8 +73,9 @@ class UsgManager(ManagerPlugin):
             return
 
         action = message["action"]
-        profile = message["profile"]
+        profile = message.get("profile")
         tailoring_file = message.get("tailoring-file")
+        assert profile is not None or tailoring_file is not None
 
         try:
             result = await self._usg_operation(
@@ -202,7 +203,7 @@ class UsgManager(ManagerPlugin):
     def _spawn_usg(
         self,
         action: str,
-        profile: str,
+        profile: str | None,
         tailoring_file: Optional[str] = None,
     ) -> Deferred:
         """Execute the correct `usg` command for message in a non-blocking
@@ -214,8 +215,10 @@ class UsgManager(ManagerPlugin):
 
         :returns: the deferred result of the usg process
         """
-        args = [USG_EXECUTABLE_ABS, action, profile]
+        args = [USG_EXECUTABLE_ABS, action]
 
+        if profile is not None:
+            args.append(profile)
         if tailoring_file is not None:
             args.extend([TAILORING_FILE_PARAM, tailoring_file])
 
@@ -235,7 +238,7 @@ class UsgManager(ManagerPlugin):
     async def _usg_operation(
         self,
         action: str,
-        profile: str,
+        profile: str | None,
         tailoring_file: Union[Tuple[str, int], None],
     ) -> str:
         """Runs usg, first downloading `tailoring_file` if it's provided.

--- a/landscape/client/manager/usgmanager.py
+++ b/landscape/client/manager/usgmanager.py
@@ -1,5 +1,4 @@
 import glob
-import logging
 import os
 import shutil
 from pathlib import Path
@@ -66,7 +65,6 @@ class UsgManager(ManagerPlugin):
 
         :message: A message of type "usg".
         """
-        logging.info(str(message))
         opid = message["operation-id"]
         runid = message["run-id"]
 
@@ -77,8 +75,6 @@ class UsgManager(ManagerPlugin):
         action = message["action"]
         profile = message.get("profile")
         tailoring_file = message.get("tailoring-file")
-        assert profile is not None or tailoring_file is not None
-        logging.info("message")
 
         try:
             result = await self._usg_operation(
@@ -86,7 +82,6 @@ class UsgManager(ManagerPlugin):
                 profile,
                 tailoring_file,
             )
-            logging.info("usg results ")
             await self._respond(SUCCEEDED, result, opid)
 
             if action == "audit":


### PR DESCRIPTION
Ensure that usg is enabled:

```sh
sudo pro attach
sudo apt update
sudo apt install ubuntu-advantage-tools
sudo pro enable usg
sudo apt install usg
```

Generate a tailoring file (will be used to generate the security profile in LS)
```sh
sudo usg generate-tailoring disa_stig .
```

connect LC to server and make sure the UsgManager plugin is enabled.
```
include_manager_plugins = UsgManager
```
execute a security profile on server
