### PR TITLE
feat: configurably exclude package sources

### DIFF
--- a/landscape/client/package/taskhandler.py
+++ b/landscape/client/package/taskhandler.py
@@ -309,7 +309,7 @@ def run_task_handler(cls, args, reactor=None):
     from landscape.lib.apt.package.facade import AptFacade
 
     package_facade = AptFacade(
-        ignore_sources=config.ignore_package_sources,
+        ignore_sources=getattr(config, "ignore_package_sources", None),
         alt_sourceparts=os.path.join(
             config.data_path,
             "landscape-sources.list.d",

--- a/landscape/client/package/taskhandler.py
+++ b/landscape/client/package/taskhandler.py
@@ -308,7 +308,13 @@ def run_task_handler(cls, args, reactor=None):
     # import Apt unless we need to.
     from landscape.lib.apt.package.facade import AptFacade
 
-    package_facade = AptFacade()
+    package_facade = AptFacade(
+        ignore_sources=config.ignore_package_sources,
+        alt_sourceparts=os.path.join(
+            config.data_path,
+            "landscape-sources.list.d",
+        ),
+    )
 
     def finish():
         connector.disconnect()

--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -70,6 +70,20 @@ class PackageReporterConfigurationTest(LandscapeTest):
         config.load(["--force-apt-update"])
         self.assertTrue(config.force_apt_update)
 
+    def test_ignore_sources_option(self):
+        """
+        `PackageReporterConfiguration` supports a '--ignore-sources' command
+        line option.
+        """
+        config = PackageReporterConfiguration()
+        config.default_config_filenames = self.makeFile("")
+        self.assertEqual(config.ignore_sources, [])
+        config.load(["--ignore-sources", "https://esm.ubuntu.com/apps/ubuntu"])
+        self.assertEqual(
+            config.ignore_sources,
+            ["https://esm.ubuntu.com/apps/ubuntu"],
+        )
+
 
 class PackageReporterAptTest(LandscapeTest):
     helpers = [AptFacadeHelper, SimpleRepositoryHelper, BrokerServiceHelper]
@@ -1188,7 +1202,7 @@ class PackageReporterAptTest(LandscapeTest):
             release.write(
                 f"Suite: {os_release_info['code-name']}-security\n"
                 "Date: Sat, 02 Jul 2016 05:20:50 +0000\n"
-                "MD5Sum: deadbeef"
+                "MD5Sum: deadbeef",
             )
 
         self.store.set_hash_ids({HASH1: 1, HASH2: 2, HASH3: 3})
@@ -1249,7 +1263,7 @@ class PackageReporterAptTest(LandscapeTest):
             release.write(
                 f"Suite: {os_release_info['code-name']}-backports\n"
                 "Date: Sat, 02 Jul 2016 05:20:50 +0000\n"
-                "MD5Sum: deadbeef"
+                "MD5Sum: deadbeef",
             )
 
         self.store.set_hash_ids({HASH1: 1, HASH2: 2, HASH3: 3})
@@ -1293,7 +1307,7 @@ class PackageReporterAptTest(LandscapeTest):
             release.write(
                 "Suite: my-personal-backports"
                 "Date: Sat, 02 Jul 2016 05:20:50 +0000\n"
-                "MD5Sum: deadbeef"
+                "MD5Sum: deadbeef",
             )
 
         self.store.set_hash_ids({HASH1: 1, HASH2: 2, HASH3: 3})
@@ -1333,14 +1347,14 @@ class PackageReporterAptTest(LandscapeTest):
             release.write(
                 f"Suite: {os_release_info['code-name']}-backports\n"
                 "Date: Sat, 02 Jul 2016 05:20:50 +0000\n"
-                "MD5Sum: deadbeef"
+                "MD5Sum: deadbeef",
             )
         unofficial_release_path = os.path.join(other_backport_dir, "Release")
         with open(unofficial_release_path, "w") as release:
             release.write(
                 "Suite: my-personal-backports\n"
                 "Date: Sat, 02 Jul 2016 05:20:50 +0000\n"
-                "MD5Sum: deadbeef"
+                "MD5Sum: deadbeef",
             )
 
         self.store.set_hash_ids({HASH1: 1, HASH2: 2, HASH3: 3})

--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -77,11 +77,20 @@ class PackageReporterConfigurationTest(LandscapeTest):
         """
         config = PackageReporterConfiguration()
         config.default_config_filenames = self.makeFile("")
-        self.assertEqual(config.ignore_sources, [])
-        config.load(["--ignore-sources", "https://esm.ubuntu.com/apps/ubuntu"])
+        self.assertIsNone(config.ignore_sources)
+        config.load(
+            [
+                "--ignore-sources",
+                "https://esm.ubuntu.com/apps/ubuntu,"
+                "https://esm2.ubuntu.com/apps/ubuntu",
+            ],
+        )
         self.assertEqual(
             config.ignore_sources,
-            ["https://esm.ubuntu.com/apps/ubuntu"],
+            {
+                "https://esm.ubuntu.com/apps/ubuntu",
+                "https://esm2.ubuntu.com/apps/ubuntu",
+            },
         )
 
 

--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -77,19 +77,18 @@ class PackageReporterConfigurationTest(LandscapeTest):
         """
         config = PackageReporterConfiguration()
         config.default_config_filenames = self.makeFile("")
-        self.assertIsNone(config.ignore_sources)
+        self.assertIsNone(config.ignore_package_sources)
         config.load(
             [
-                "--ignore-sources",
-                "https://esm.ubuntu.com/apps/ubuntu,"
-                "https://esm2.ubuntu.com/apps/ubuntu",
+                "--ignore-package-sources",
+                "my-random-source.list," "my-fancy-source.sources",
             ],
         )
         self.assertEqual(
-            config.ignore_sources,
+            config.ignore_package_sources,
             {
-                "https://esm.ubuntu.com/apps/ubuntu",
-                "https://esm2.ubuntu.com/apps/ubuntu",
+                "my-random-source.list",
+                "my-fancy-source.sources",
             },
         )
 
@@ -1696,8 +1695,10 @@ class PackageReporterAptTest(LandscapeTest):
             self.assertEqual("error", err)
             self.assertEqual(2, code)
             warning_mock.assert_called_once_with(
-                f"'{self.reporter.apt_update_filename}' "
-                "exited with status 2 (error)",
+                "'%s' exited with status %d (%s)",
+                self.reporter.apt_update_filename,
+                2,
+                "error",
             )
 
         result.addCallback(callback)
@@ -1740,9 +1741,10 @@ class PackageReporterAptTest(LandscapeTest):
             mock.call(message.format(20)),
             mock.call(message.format(40)),
             mock.call(
-                "'{}' exited with status 100 ()".format(
-                    self.reporter.apt_update_filename,
-                ),
+                "'%s' exited with status %d (%s)",
+                self.reporter.apt_update_filename,
+                100,
+                "",
             ),
         ]
         logging_mock.assert_has_calls(calls)

--- a/landscape/lib/apt/package/facade.py
+++ b/landscape/lib/apt/package/facade.py
@@ -182,8 +182,6 @@ class AptFacade:
 
         os.makedirs(alt_sourceparts, exist_ok=True)
 
-        # Set config to use landscape-sources.list.d instead of sources.list.d
-        # Copy non-ignored sources to landscape-sources.list.d.
         sourceparts = apt_pkg.config.find_dir("Dir::Etc::sourceparts")
 
         for sourcepart in os.scandir(sourceparts):

--- a/landscape/lib/apt/package/facade.py
+++ b/landscape/lib/apt/package/facade.py
@@ -1,10 +1,12 @@
 import hashlib
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Container
 from operator import attrgetter
 
 import apt
@@ -120,8 +122,10 @@ class AptFacade:
     This object wraps Apt features, in a way that makes using and testing
     these features slightly more comfortable.
 
-    @param root: The root dir of the Apt configuration files.
-    @ivar refetch_package_index: Whether to refetch the package indexes
+    :param root: The root dir of the Apt configuration files.
+    :param ignore_sources: Sources with URIs in this container are reloaded and
+        their packages are not considered during reporting.
+    :ivar refetch_package_index: Whether to refetch the package indexes
         when reloading the channels, or reuse the existing local
         database.
     """
@@ -130,7 +134,12 @@ class AptFacade:
     dpkg_retry_sleep = 5
     _dpkg_status = "/var/lib/dpkg/status"
 
-    def __init__(self, root=None):
+    def __init__(
+        self,
+        root: str | None = None,
+        ignore_sources: Container = {},
+        alt_sourceparts: str = "",
+    ) -> None:
         self._root = root
         self._dpkg_args = []
         if self._root is not None:
@@ -149,6 +158,45 @@ class AptFacade:
         self._version_hold_creations = []
         self._version_hold_removals = []
         self.refetch_package_index = False
+
+        if ignore_sources and alt_sourceparts:
+            self._configure_apt_cache(ignore_sources, alt_sourceparts)
+
+    def _configure_apt_cache(
+        self,
+        ignore_sources: Container,
+        alt_sourceparts,
+    ) -> None:
+        """Configures the cache to only use sources not in `ignore_sources`.
+
+        This is done by configuring apt to use a different directory for the
+        "sourceparts" config rather than the usual "/etc/apt/sources.list.d".
+
+        See apt.cache.Cache.update for an example of how this works.
+        """
+        if os.path.exists(alt_sourceparts):
+            try:
+                shutil.rmtree(alt_sourceparts)
+            except NotADirectoryError:
+                os.remove(alt_sourceparts)
+
+        os.makedirs(alt_sourceparts, exist_ok=True)
+
+        # Set config to use landscape-sources.list.d instead of sources.list.d
+        # Copy non-ignored sources to landscape-sources.list.d.
+        sourceparts = apt_pkg.config.find_dir("Dir::Etc::sourceparts")
+
+        for sourcepart in os.scandir(sourceparts):
+            name = sourcepart.name
+            if name not in ignore_sources:
+                logging.debug("Copying source %s to %s", name, alt_sourceparts)
+                shutil.copy(sourcepart, alt_sourceparts)
+            else:
+                logging.debug("Ignoring source %s", name)
+
+        apt_pkg.config.set("Dir::Etc::sourceparts", alt_sourceparts)
+
+        self._cache = apt.cache.Cache(rootdir=self._root)
 
     def _ensure_dir_structure(self):
         apt_dir = self._ensure_sub_dir("etc/apt")
@@ -254,9 +302,9 @@ class AptFacade:
                 except TypeError:
                     self._cache.update()
             except apt.cache.FetchFailedException:
-                raise ChannelError(
-                    f"Apt failed to reload channels ({self.get_channels()!r})",
-                )
+                channels = self.get_channels()
+                msg = f"Apt failed to reload channels ({channels!r})"
+                raise ChannelError(msg)
             self._cache.open(None)
 
         self._pkg2hash.clear()

--- a/landscape/lib/apt/package/tests/test_facade.py
+++ b/landscape/lib/apt/package/tests/test_facade.py
@@ -3609,6 +3609,13 @@ class AptFacadeTest(
         `ignore_sources`. The facade then uses `alt_sourceparts` for cache
         operations.
         """
+        self.addCleanup(apt_pkg.config.set, "Dir", apt_pkg.config.get("Dir"))
+        self.addCleanup(
+            apt_pkg.config.set,
+            "Dir::Etc::sourceparts",
+            apt_pkg.config.get("Dir::Etc::sourceparts"),
+        )
+
         root = self.makeDir()
         apt_pkg.config.set("Dir", root)
         etc = apt_pkg.config.find_dir("Dir::Etc")


### PR DESCRIPTION
This change adds a configuration option `ignore_package_sources` or `--ignore-package-sources` that can be used to ignore specific source parts in `/etc/apt/sources.list.d`.

To test, add this line to your client.conf (or root-client.conf):
```
ignore_package_sources = landscape-ubuntu-self-hosted-beta-jammy.list
```
don't use `jammy` unless you're on jammy.

Then add that repo: `sudo add-apt-repository ppa:landscape/self-hosted-beta`
and run your client

```
sudo ./scripts/landscape-client --config ./root-client.conf
```

wait for your client to finish reporting packages.

Check that packages from the ignored source do not show up when searching packages, e.g., `landscape-server`. For this client.