### PR TITLE
feat: log pending message count

### DIFF
--- a/landscape/client/broker/exchange.py
+++ b/landscape/client/broker/exchange.py
@@ -890,7 +890,8 @@ class MessageExchange:
             message_store.commit()
 
         if message_store.get_pending_messages(1):
-            logging.info("Pending messages remain after the last exchange.")
+            count = message_store.count_pending_messages()
+            logging.info("Pending messages remaining after the last exchange: %d", count)
             # Either the server asked us for old messages, or we
             # otherwise have more messages even after transferring
             # what we could.

--- a/landscape/client/broker/exchange.py
+++ b/landscape/client/broker/exchange.py
@@ -342,6 +342,7 @@ Diagram::
   14. Schedule exchange
 
 """
+
 import logging
 import time
 
@@ -891,7 +892,10 @@ class MessageExchange:
 
         if message_store.get_pending_messages(1):
             count = message_store.count_pending_messages()
-            logging.info("Pending messages remaining after the last exchange: %d", count)
+            logging.info(
+                "Pending messages remaining after the last exchange: %d",
+                count,
+            )
             # Either the server asked us for old messages, or we
             # otherwise have more messages even after transferring
             # what we could.


### PR DESCRIPTION
https://warthogs.atlassian.net/browse/LNDENG-2247

---

## Manual testing

Connect a client running this branch to Landscape Server and wait for a couple of minutes. Then, in the Client instance, check for the new log entry in `broker.log`:

```
#root@landscape-client-jammy:/tmp/landscape
cat broker.log | grep "Pending messages"
...
2025-05-27 19:35:07,203 INFO     [MainThread] Pending messages remaining after the last exchange: 1
```