### PR TITLE
Lndeng 2596 unknown hashes per request is configurable

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -218,3 +218,9 @@ manager_plugins = ALL
 # should match the uid assigned to the host machine.
 # For all other computers, do not set this parameter.
 #hostagent_uid = the-uid-of-the-host-machine
+
+# This parameter determines how many unknown package hashes client
+# will send to server at one time. The default is 500 and the maximum
+# is 2000. Note that increasing the value may result in higher CPU usage
+# by the client machine during this package reporting.
+#max_unknown_hashes_per_request = 500

--- a/landscape/client/package/reporter.py
+++ b/landscape/client/package/reporter.py
@@ -37,7 +37,8 @@ from landscape.client.package.taskhandler import (
 
 
 HASH_ID_REQUEST_TIMEOUT = 7200
-MAX_UNKNOWN_HASHES_PER_REQUEST = 500
+DEFAULT_UNKNOWN_HASHES_PER_REQUEST = 500
+MAX_UNKNOWN_HASHES_PER_REQUEST = 2000
 LOCK_RETRY_DELAYS = [0, 20, 40]
 PYTHON_BIN = "/usr/bin/python3"
 RELEASE_UPGRADER_PATTERN = "/tmp/ubuntu-release-upgrader-"
@@ -46,7 +47,7 @@ UID_ROOT = "0"
 
 def sources_list(string: str) -> set[str]:
     """
-    Parser for converting a comma-seperated string of URLs into a list of
+    Parser for converting a comma-separated string of URLs into a list of
     validated URLs.
     """
     urls = [url.strip() for url in string.split(",")]
@@ -65,6 +66,21 @@ def sources_list(string: str) -> set[str]:
         raise ArgumentTypeError(invalid_urls)
 
     return set(valid_urls)
+
+
+def unknown_hash_limit(limit: str) -> int:
+    limit = int(limit)
+    if limit <= 0:
+        raise ArgumentTypeError("")
+
+    if limit > MAX_UNKNOWN_HASHES_PER_REQUEST:
+        logging.warning(
+            "Parsed value is larger than the maximum allowed. "
+            "Using the maximum instead: %d",
+            MAX_UNKNOWN_HASHES_PER_REQUEST,
+        )
+        return MAX_UNKNOWN_HASHES_PER_REQUEST
+    return limit
 
 
 class PackageReporterConfiguration(PackageTaskHandlerConfiguration):
@@ -99,6 +115,19 @@ class PackageReporterConfiguration(PackageTaskHandlerConfiguration):
             help=(
                 "Comma-delimited list of package source files to be ignored "
                 "when reporting packages."
+            ),
+        )
+        parser.add_argument(
+            "--max-unknown-hashes-per-request",
+            default=DEFAULT_UNKNOWN_HASHES_PER_REQUEST,
+            type=unknown_hash_limit,
+            help=(
+                "The maximum number of packages with unknown hashes to send "
+                "to Landscape Server in each message exchange. The default "
+                " is 500 and the maximum is 2000. Note that with higher "
+                "values, Landscape Server will receive the initial package "
+                "data more quickly, but at the cost of high CPU usage by "
+                "Landscape Client."
             ),
         )
         return parser
@@ -272,7 +301,7 @@ class PackageReporter(PackageTaskHandler):
         """Detect whether ubuntu-release-upgrader is running.
 
         This is done by iterating the /proc tree (to avoid external
-        dependencies) and checkign the cmdline and the uid of the process.
+        dependencies) and checking the cmdline and the uid of the process.
         The assumption is that ubuntu-release-upgrader is something that:
             * is run by a python interpreter
             * its first argument starts with '/tmp/ubuntu-release-upgrader-'
@@ -602,8 +631,11 @@ class PackageReporter(PackageTaskHandler):
         if not unknown_hashes:
             result = succeed(None)
         else:
+            max_unknown_hashes_per_request = (
+                self._config.max_unknown_hashes_per_request
+            )
             unknown_hashes = sorted(unknown_hashes)
-            unknown_hashes = unknown_hashes[:MAX_UNKNOWN_HASHES_PER_REQUEST]
+            unknown_hashes = unknown_hashes[:max_unknown_hashes_per_request]
 
             logging.info(
                 "Queuing request for package hash => id "

--- a/landscape/client/package/reporter.py
+++ b/landscape/client/package/reporter.py
@@ -124,7 +124,7 @@ class PackageReporterConfiguration(PackageTaskHandlerConfiguration):
             help=(
                 "The maximum number of packages with unknown hashes to send "
                 "to Landscape Server in each message exchange. The default "
-                " is 500 and the maximum is 2000. Note that with higher "
+                "is 500 and the maximum is 2000. Note that with higher "
                 "values, Landscape Server will receive the initial package "
                 "data more quickly, but at the cost of high CPU usage by "
                 "Landscape Client."

--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import logging
 import os
 import shutil
@@ -14,11 +16,15 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.internet.defer import succeed
 
 from landscape.client.package import reporter
+from landscape.client.package.reporter import (
+    DEFAULT_UNKNOWN_HASHES_PER_REQUEST,
+)
 from landscape.client.package.reporter import FakeGlobalReporter
 from landscape.client.package.reporter import FakeReporter
 from landscape.client.package.reporter import find_reporter_command
 from landscape.client.package.reporter import HASH_ID_REQUEST_TIMEOUT
 from landscape.client.package.reporter import main
+from landscape.client.package.reporter import MAX_UNKNOWN_HASHES_PER_REQUEST
 from landscape.client.package.reporter import PackageReporter
 from landscape.client.package.reporter import PackageReporterConfiguration
 from landscape.client.tests.helpers import BrokerServiceHelper
@@ -90,6 +96,143 @@ class PackageReporterConfigurationTest(LandscapeTest):
                 "my-random-source.list",
                 "my-fancy-source.sources",
             },
+        )
+
+    def test_max_unknown_hashes_per_request_default(self):
+        config = PackageReporterConfiguration()
+        config.default_config_filenames = self.makeFile("")
+
+        self.assertEqual(
+            DEFAULT_UNKNOWN_HASHES_PER_REQUEST,
+            config.max_unknown_hashes_per_request,
+        )
+
+    def test_max_unknown_hashes_per_request_file_config(self):
+        config = PackageReporterConfiguration()
+        filename = self.makeFile(
+            "[client]\nmax_unknown_hashes_per_request = 5",
+        )
+        config.load(["--config", filename])
+
+        self.assertEqual(
+            5,
+            config.max_unknown_hashes_per_request,
+        )
+
+    def test_max_unknown_hashes_per_request_parameter(self):
+        config = PackageReporterConfiguration()
+        config.default_config_filenames = self.makeFile("")
+
+        config.load(
+            [
+                "--max-unknown-hashes-per-request",
+                "100",
+            ],
+        )
+
+        self.assertEqual(100, config.max_unknown_hashes_per_request)
+
+    def test_max_unknown_hashes_per_request_parameter_overrides_file(self):
+        config = PackageReporterConfiguration()
+        filename = self.makeFile(
+            "[client]\nmax_unknown_hashes_per_request = 5",
+        )
+        config.load(
+            [
+                "--config",
+                filename,
+                "--max-unknown-hashes-per-request",
+                "100",
+            ],
+        )
+
+        self.assertEqual(100, config.max_unknown_hashes_per_request)
+
+    def test_max_unknown_hashes_per_request_parameter_maximum(self):
+        config = PackageReporterConfiguration()
+        config.load(
+            [
+                "--max-unknown-hashes-per-request",
+                str(MAX_UNKNOWN_HASHES_PER_REQUEST + 1),
+            ],
+        )
+
+        self.assertEqual(
+            MAX_UNKNOWN_HASHES_PER_REQUEST,
+            config.max_unknown_hashes_per_request,
+        )
+
+    def test_max_unknown_hashes_per_request_file_maximum(self):
+        config = PackageReporterConfiguration()
+        filename = self.makeFile(
+            "[client]\nmax_unknown_hashes_per_request = "
+            f"{MAX_UNKNOWN_HASHES_PER_REQUEST + 1}",
+        )
+        config.load(["--config", filename])
+
+        self.assertEqual(
+            MAX_UNKNOWN_HASHES_PER_REQUEST,
+            config.max_unknown_hashes_per_request,
+        )
+
+    def test_negative_max_unknown_hashes_per_request_raises(self):
+        config = PackageReporterConfiguration()
+
+        fake_stderr = io.StringIO()
+        with self.assertRaises(SystemExit) as ctx, contextlib.redirect_stderr(
+            fake_stderr,
+        ):
+            config.load(
+                [
+                    "--max-unknown-hashes-per-request",
+                    "-1",
+                ],
+            )
+        self.assertEqual(2, ctx.exception.code)
+        error_message = fake_stderr.getvalue()
+        self.assertIn(
+            "error: argument --max-unknown-hashes-per-request",
+            error_message,
+        )
+
+    def test_zero_max_unknown_hashes_per_request_raises(self):
+        config = PackageReporterConfiguration()
+
+        fake_stderr = io.StringIO()
+        with self.assertRaises(SystemExit) as ctx, contextlib.redirect_stderr(
+            fake_stderr,
+        ):
+            config.load(
+                [
+                    "--max-unknown-hashes-per-request",
+                    "0",
+                ],
+            )
+        self.assertEqual(2, ctx.exception.code)
+        error_message = fake_stderr.getvalue()
+        self.assertIn(
+            "error: argument --max-unknown-hashes-per-request",
+            error_message,
+        )
+
+    def test_non_integer_max_unknown_hashes_per_request_raises(self):
+        config = PackageReporterConfiguration()
+
+        fake_stderr = io.StringIO()
+        with self.assertRaises(SystemExit) as ctx, contextlib.redirect_stderr(
+            fake_stderr,
+        ):
+            config.load(
+                [
+                    "--max-unknown-hashes-per-request",
+                    "0.5",
+                ],
+            )
+        self.assertEqual(2, ctx.exception.code)
+        error_message = fake_stderr.getvalue()
+        self.assertIn(
+            "error: argument --max-unknown-hashes-per-request",
+            error_message,
         )
 
 
@@ -841,14 +984,12 @@ class PackageReporterAptTest(LandscapeTest):
         message_store = self.broker_service.message_store
         message_store.set_accepted_types(["unknown-package-hashes"])
 
-        self.addCleanup(
-            setattr,
-            reporter,
-            "MAX_UNKNOWN_HASHES_PER_REQUEST",
-            reporter.MAX_UNKNOWN_HASHES_PER_REQUEST,
+        self.config.load(
+            [
+                "--max-unknown-hashes-per-request",
+                "2",
+            ],
         )
-
-        reporter.MAX_UNKNOWN_HASHES_PER_REQUEST = 2
 
         def got_result1(result):
             # The first message sent should send any 2 of the 3 hashes.


### PR DESCRIPTION


```
ubuntu@landscape-client-jammy:~/landscape-client$ cat landscape-client.conf 
[client]
bus = session
computer_title = dev-client
account_name = bill-kronholm
registration_key = REDACTED
url = https://landscape.canonical.com/message-system
data_path = /tmp/landscape/
log_dir = /tmp/landscape/
log_level = debug
pid_file = /tmp/landscape/landscape-client.pid
ping_url = http://landscape.canonical.com/ping
max_unknown_hashes_per_request = 20
include_manager_plugins = ScriptExecution
script_users = landscape,ubuntu
```

```
ubuntu@landscape-client-jammy:/tmp/landscape$ grep -rnw . -e "Queuing request"
./package-reporter.log:29:2025-05-27 23:40:07,116 INFO     [MainThread] Queuing request for package hash => id translation on 20 hash(es).
./package-reporter.log:60:2025-05-27 23:42:15,396 INFO     [MainThread] Queuing request for package hash => id translation on 20 hash(es).
./package-reporter.log:92:2025-05-27 23:43:40,489 INFO     [MainThread] Queuing request for package hash => id translation on 20 hash(es).
./package-reporter.log:124:2025-05-27 23:44:42,100 INFO     [MainThread] Queuing request for package hash => id translation on 20 hash(es).
```