### PR TITLE
revert: added /writable system-files interface to for script access (#272)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,11 +31,7 @@ plugs:
       - /var/lib/snapd/hostfs/var/lib/ubuntu-advantage/status.json
   snapd-control-managed:
     interface: snapd-control
-    refresh-schedule: managed  
-  writable:
-    interface: system-files
-    write:
-      - /writable
+    refresh-schedule: managed
 
 slots:
   annotations:
@@ -64,7 +60,6 @@ apps:
       - network-manager
       - log-observe
       - var-lib-ubuntu-advantage-status
-      - writable
   config:
     command: usr/bin/landscape-config
     plugs:


### PR DESCRIPTION
After some discussion [on the forum](https://forum.snapcraft.io/t/installation-request-for-landscape-client-writable-system-files/47209), it's been decided that #272 should be reverted. Please see the discussion there.

The tl;dr is, `/writable` has far-reaching implications since it's [the rootfs](https://github.com/canonical/snapd/blob/75d252871e4217fe32126c9e857510951a9fc8a1/dirs/dirs.go#L157) Ubuntu Core 🙂.
