### PR TITLE
refactor: remove oboslete client-uptime message schema

### DIFF
--- a/landscape/message_schemas/server_bound.py
+++ b/landscape/message_schemas/server_bound.py
@@ -16,7 +16,6 @@ from landscape.lib.schema import Unicode
 __all__ = [
     "ACTIVE_PROCESS_INFO",
     "COMPUTER_UPTIME",
-    "CLIENT_UPTIME",
     "CLOUD_INIT",
     "OPERATION_RESULT",
     "COMPUTER_INFO",
@@ -114,12 +113,6 @@ COMPUTER_UPTIME = Message(
     # XXX Again, one or the other.
     optional=["startup-times", "shutdown-times"],
 )
-
-CLIENT_UPTIME = Message(
-    "client-uptime",
-    {"period": Tuple(Float(), Float()), "components": List(Int())},
-    optional=["components"],
-)  # just for backwards compatibility
 
 OPERATION_RESULT = Message(
     "operation-result",
@@ -852,7 +845,6 @@ USG_AUDIT = Message(
 message_schemas = (
     ACTIVE_PROCESS_INFO,
     COMPUTER_UPTIME,
-    CLIENT_UPTIME,
     CLOUD_INIT,
     OPERATION_RESULT,
     COMPUTER_INFO,


### PR DESCRIPTION
`landscape-client` does not send this message and `landscape-server` does not have a handler for it. In fact, `landscape-server` dropped the corresponding table from the resource database in patch 29.