### PR TITLE
feat: add machine-id to registration and computer info

### DIFF
--- a/landscape/client/monitor/computerinfo.py
+++ b/landscape/client/monitor/computerinfo.py
@@ -9,6 +9,7 @@ from landscape.client.snap_utils import get_snap_info
 from landscape.lib.cloud import fetch_ec2_meta_data
 from landscape.lib.fetch import fetch_async
 from landscape.lib.fs import read_text_file
+from landscape.lib.machine_id import get_namespaced_machine_id
 from landscape.lib.network import get_fqdn
 from landscape.lib.os_release import get_os_filename
 from landscape.lib.os_release import parse_os_release
@@ -142,6 +143,7 @@ class ComputerInfo(MonitorPlugin):
         total_memory, total_swap = self._get_memory_info()
         self._add_if_new(message, "total-memory", total_memory)
         self._add_if_new(message, "total-swap", total_swap)
+        self._add_if_new(message, "machine-id", self._get_machine_id())
         annotations = {}
         if os.path.exists(self._annotations_path):
             for key in os.listdir(self._annotations_path):
@@ -178,6 +180,10 @@ class ComputerInfo(MonitorPlugin):
                     message[key] = value
         file.close()
         return (message["MemTotal"] // 1024, message["SwapTotal"] // 1024)
+
+    def _get_machine_id(self) -> str:
+        """Gets a UUID string from the machine id"""
+        return str(get_namespaced_machine_id())
 
     def _get_distribution_info(self):
         """Get details about the distribution."""

--- a/landscape/client/monitor/computerinfo.py
+++ b/landscape/client/monitor/computerinfo.py
@@ -183,7 +183,7 @@ class ComputerInfo(MonitorPlugin):
 
     def _get_machine_id(self) -> str:
         """Gets a UUID string from the machine id"""
-        return str(get_namespaced_machine_id())
+        return get_namespaced_machine_id()
 
     def _get_distribution_info(self):
         """Get details about the distribution."""

--- a/landscape/client/registration.py
+++ b/landscape/client/registration.py
@@ -21,6 +21,7 @@ from landscape.client.exchange import exchange_messages
 from landscape.client.manager.ubuntuproinfo import get_ubuntu_pro_info
 from landscape.lib.fetch import HTTPCodeError
 from landscape.lib.fetch import PyCurlError
+from landscape.lib.machine_id import get_namespaced_machine_id
 from landscape.lib.network import get_fqdn
 from landscape.lib.vm_info import get_container_info
 from landscape.lib.vm_info import get_vm_info
@@ -44,6 +45,7 @@ class ClientRegistrationInfo:
     tags: Optional[str] = None
     ubuntu_pro_info: Optional[str] = None
     vm_info: Optional[bytes] = None
+    machine_id: Optional[str] = None
 
     @classmethod
     def from_identity(
@@ -64,6 +66,7 @@ class ClientRegistrationInfo:
             tags=identity.tags,
             ubuntu_pro_info=json.dumps(get_ubuntu_pro_info()),
             vm_info=get_vm_info(),
+            machine_id=get_namespaced_machine_id(),
         )
 
 

--- a/landscape/lib/machine_id.py
+++ b/landscape/lib/machine_id.py
@@ -9,9 +9,9 @@ __all__ = [
     "MACHINE_ID_SIZE",
 ]
 
-# Used to hash machine ids for client instances.
+# Used to build a namespaced-uuid from the machine ids of client instances.
 # It was generated using `uuidgen -r`
-# This value should never change.
+# This value should never change. Ever.
 LANDSCAPE_CLIENT_APP_UUID = uuid.UUID("534a0cda-35a7-4f8a-a5cb-d8d9bb24a790")
 
 # https://manpages.ubuntu.com/manpages/bionic/man5/machine-id.5.html
@@ -27,12 +27,12 @@ def _get_machine_id() -> str:
     return machine_id
 
 
-def get_namespaced_machine_id() -> uuid.UUID | None:
+def get_namespaced_machine_id() -> str | None:
     try:
         machine_id = _get_machine_id()
     except Exception as e:
         logging.warning(str(e))
-        return None
+        return
     if not machine_id:
         return
-    return uuid.uuid5(LANDSCAPE_CLIENT_APP_UUID, machine_id)
+    return str(uuid.uuid5(LANDSCAPE_CLIENT_APP_UUID, machine_id))

--- a/landscape/lib/machine_id.py
+++ b/landscape/lib/machine_id.py
@@ -1,0 +1,38 @@
+import logging
+import uuid
+
+# exclude _get_machine_id
+__all__ = [
+    "get_namespaced_machine_id",
+    "LANDSCAPE_CLIENT_APP_UUID",
+    "MACHINE_ID_FILE",
+    "MACHINE_ID_SIZE",
+]
+
+# Used to hash machine ids for client instances.
+# It was generated using `uuidgen -r`
+# This value should never change.
+LANDSCAPE_CLIENT_APP_UUID = uuid.UUID("534a0cda-35a7-4f8a-a5cb-d8d9bb24a790")
+
+# https://manpages.ubuntu.com/manpages/bionic/man5/machine-id.5.html
+# We expect 32 ASCII characters, so we won't read in any more than
+# the expected 32 bytes.
+MACHINE_ID_FILE = "/etc/machine-id"
+MACHINE_ID_SIZE = 32
+
+
+def _get_machine_id() -> str:
+    with open(MACHINE_ID_FILE, "r") as f:
+        machine_id = f.read(MACHINE_ID_SIZE)
+    return machine_id
+
+
+def get_namespaced_machine_id() -> uuid.UUID | None:
+    try:
+        machine_id = _get_machine_id()
+    except Exception as e:
+        logging.warning(str(e))
+        return None
+    if not machine_id:
+        return
+    return uuid.uuid5(LANDSCAPE_CLIENT_APP_UUID, machine_id)

--- a/landscape/lib/tests/test_machine_id.py
+++ b/landscape/lib/tests/test_machine_id.py
@@ -12,7 +12,7 @@ from landscape.lib.machine_id import MACHINE_ID_SIZE
 class NameSpacedMachineIdTest(testing.FSTestCase, unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.machine_id = "61f88a7a-d8aa-4a4a-9046-975e5884"
+        self.machine_id = "61f88a7a7d8aa74a4a790467975e5884"
         self.assertEqual(MACHINE_ID_SIZE, len(self.machine_id))
         self.machine_id_file = self.makeFile(content=self.machine_id)
 

--- a/landscape/lib/tests/test_machine_id.py
+++ b/landscape/lib/tests/test_machine_id.py
@@ -1,0 +1,65 @@
+import os
+import unittest
+import uuid
+from unittest import mock
+
+from landscape.lib import testing
+from landscape.lib.machine_id import get_namespaced_machine_id
+from landscape.lib.machine_id import LANDSCAPE_CLIENT_APP_UUID
+from landscape.lib.machine_id import MACHINE_ID_SIZE
+
+
+class NameSpacedMachineIdTest(testing.FSTestCase, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.machine_id = "61f88a7a-d8aa-4a4a-9046-975e5884"
+        self.assertEqual(MACHINE_ID_SIZE, len(self.machine_id))
+        self.machine_id_file = self.makeFile(content=self.machine_id)
+
+        mock.patch(
+            "landscape.lib.machine_id.MACHINE_ID_FILE",
+            self.machine_id_file,
+        ).start()
+
+        self.addCleanup(mock.patch.stopall)
+
+    def test_get_namespaced_machine_id(self):
+        expected = uuid.uuid5(LANDSCAPE_CLIENT_APP_UUID, self.machine_id)
+        self.assertEqual(expected, get_namespaced_machine_id())
+
+    def test_empty_file(self):
+        empty_file = self.makeFile(content="")
+
+        with mock.patch(
+            "landscape.lib.machine_id.MACHINE_ID_FILE",
+            empty_file,
+        ):
+            found = get_namespaced_machine_id()
+
+        self.assertIsNone(found)
+
+    def test_missing_file(self):
+        some_file = self.makeFile(content="this message will self-destruct")
+        os.unlink(some_file)
+
+        with mock.patch("landscape.lib.machine_id.MACHINE_ID_FILE", some_file):
+            found = get_namespaced_machine_id()
+
+        self.assertIsNone(found)
+
+    def test_contents_truncated(self):
+        too_long_machine_id = self.machine_id + "0123456789abcdef"
+        self.assertEqual(
+            self.machine_id,
+            too_long_machine_id[:MACHINE_ID_SIZE],
+        )
+        big_machine_id_file = self.makeFile(content=too_long_machine_id)
+
+        with mock.patch(
+            "landscape.lib.machine_id.MACHINE_ID_FILE",
+            big_machine_id_file,
+        ):
+            found = get_namespaced_machine_id()
+
+        expected = uuid.uuid5(LANDSCAPE_CLIENT_APP_UUID, self.machine_id)
+        self.assertEqual(expected, found)

--- a/landscape/lib/tests/test_machine_id.py
+++ b/landscape/lib/tests/test_machine_id.py
@@ -24,7 +24,7 @@ class NameSpacedMachineIdTest(testing.FSTestCase, unittest.TestCase):
         self.addCleanup(mock.patch.stopall)
 
     def test_get_namespaced_machine_id(self):
-        expected = uuid.uuid5(LANDSCAPE_CLIENT_APP_UUID, self.machine_id)
+        expected = str(uuid.uuid5(LANDSCAPE_CLIENT_APP_UUID, self.machine_id))
         self.assertEqual(expected, get_namespaced_machine_id())
 
     def test_empty_file(self):
@@ -61,5 +61,5 @@ class NameSpacedMachineIdTest(testing.FSTestCase, unittest.TestCase):
         ):
             found = get_namespaced_machine_id()
 
-        expected = uuid.uuid5(LANDSCAPE_CLIENT_APP_UUID, self.machine_id)
+        expected = str(uuid.uuid5(LANDSCAPE_CLIENT_APP_UUID, self.machine_id))
         self.assertEqual(expected, found)

--- a/landscape/message_schemas/server_bound.py
+++ b/landscape/message_schemas/server_bound.py
@@ -123,10 +123,17 @@ COMPUTER_INFO = Message(
         "total-memory": Int(),
         "total-swap": Int(),
         "annotations": Dict(Unicode(), Unicode()),
+        "machine-id": Unicode(),
     },
     # Not sure why these are all optional, but it's explicitly tested
     # in the server
-    optional=["hostname", "total-memory", "total-swap", "annotations"],
+    optional=[
+        "hostname",
+        "total-memory",
+        "total-swap",
+        "annotations",
+        "machine-id",
+    ],
 )
 
 DISTRIBUTION_INFO = Message(
@@ -323,6 +330,7 @@ REGISTER_3_3 = Message(
         "hostagent_uid": Unicode(),
         "installation_request_id": Unicode(),
         "authenticated_attach_code": Unicode(),
+        "machine-id": Unicode(),
     },
     api=b"3.3",
     optional=[
@@ -338,6 +346,7 @@ REGISTER_3_3 = Message(
         "hostagent_uid",
         "installation_request_id",
         "authenticated_attach_code",
+        "machine-id",
     ],
 )
 


### PR DESCRIPTION
# Manual Testing Instructions

Enable debug logging in `client.conf` and point it to your Landscape.
Register with Landscape using the dev scripts.
Check the `machine-id` is sent upon registration and then later with the first `computer-info`.
Check the values sent in those two messages match each other.
Check the value differs from your dev machine's real `machine-id` in `/etc/machine-id`