### PR TITLE
feat: add --script-tempdir configuration

### DIFF
--- a/landscape/client/broker/client.py
+++ b/landscape/client/broker/client.py
@@ -5,6 +5,7 @@ from logging import debug
 from logging import error
 from logging import exception
 from logging import info
+from typing import TYPE_CHECKING
 
 from twisted.internet.defer import maybeDeferred
 from twisted.internet.defer import succeed
@@ -12,6 +13,9 @@ from twisted.internet.defer import succeed
 from landscape.client.amp import remote
 from landscape.lib.format import format_object
 from landscape.lib.twisted_util import gather_results
+
+if TYPE_CHECKING:
+    from landscape.client.broker.config import BrokerConfiguration
 
 
 class HandlerNotFoundError(Exception):
@@ -44,7 +48,7 @@ class BrokerClientPlugin:
     _session_id = None
     _loop = None
 
-    def register(self, client):
+    def register(self, client: "BrokerClient"):
         self.client = client
         self.client.reactor.call_on("resynchronize", self._resynchronize)
         deferred = self.client.broker.get_session_id(scope=self.scope)
@@ -171,7 +175,7 @@ class BrokerClient:
 
     name = "client"
 
-    def __init__(self, reactor, config):
+    def __init__(self, reactor, config: "BrokerConfiguration"):
         super().__init__()
         self.reactor = reactor
         self.broker = None

--- a/landscape/client/deployment.py
+++ b/landscape/client/deployment.py
@@ -177,7 +177,8 @@ class Configuration(BaseConfiguration):
             "--script-tempdir",
             default=None,
             type=str,
-            help="The working directory to use for script executions.",
+            help="The working directory to use for script executions. "
+            "Must have read, write, and exec privileges for any script users.",
         )
 
         # Hidden options, used for load-testing to run in-process clones

--- a/landscape/client/deployment.py
+++ b/landscape/client/deployment.py
@@ -173,6 +173,19 @@ class Configuration(BaseConfiguration):
             type=int,
             help="The interval between snap monitor runs (default 1800).",
         )
+        parser.add_argument(
+            "--script-tempdir",
+            default=None,
+            type=str,
+            help="The working directory to use for script executions.",
+        )
+        parser.add_argument(
+            "--script-attachment-tempdir",
+            default=None,
+            type=str,
+            help="The working directory to use for script execution "
+            "attachments.",
+        )
 
         # Hidden options, used for load-testing to run in-process clones
         parser.add_argument("--clones", default=0, type=int, help=SUPPRESS)

--- a/landscape/client/deployment.py
+++ b/landscape/client/deployment.py
@@ -179,13 +179,6 @@ class Configuration(BaseConfiguration):
             type=str,
             help="The working directory to use for script executions.",
         )
-        parser.add_argument(
-            "--script-attachment-tempdir",
-            default=None,
-            type=str,
-            help="The working directory to use for script execution "
-            "attachments.",
-        )
 
         # Hidden options, used for load-testing to run in-process clones
         parser.add_argument("--clones", default=0, type=int, help=SUPPRESS)

--- a/landscape/client/manager/scriptexecution.py
+++ b/landscape/client/manager/scriptexecution.py
@@ -157,12 +157,10 @@ class ScriptExecutionPlugin(ManagerPlugin, ScriptRunnerMixin):
         self,
         process_factory=None,
         script_tempdir: str | None = None,
-        script_attachment_tempdir: str | None = None,
     ):
         ScriptRunnerMixin.__init__(self, process_factory=process_factory)
         ManagerPlugin.__init__(self)
         self.script_tempdir = script_tempdir
-        self.script_attachment_tempdir = script_attachment_tempdir
 
     def register(self, registry):
         super().register(registry)
@@ -244,7 +242,7 @@ class ScriptExecutionPlugin(ManagerPlugin, ScriptRunnerMixin):
             return self._respond(FAILED, str(failure), opid)
 
     async def _save_attachments(self, attachments, uid, gid, env):
-        attachment_dir = tempfile.mkdtemp(dir=self.script_attachment_tempdir)
+        attachment_dir = tempfile.mkdtemp(dir=self.script_tempdir)
         env["LANDSCAPE_ATTACHMENTS"] = attachment_dir
         os.chmod(attachment_dir, 0o700)
 
@@ -445,7 +443,6 @@ class ScriptExecution(ManagerPlugin):
         super().register(client)
         self._script_execution = ScriptExecutionPlugin(
             script_tempdir=self.manager.config.script_tempdir,
-            script_attachment_tempdir=self.manager.config.script_attachment_tempdir,  # noqa: E501
         )
         self._custom_graph = CustomGraphPlugin()
 

--- a/landscape/client/manager/service.py
+++ b/landscape/client/manager/service.py
@@ -45,9 +45,6 @@ class ManagerService(LandscapeService):
                     "See `example.conf` for a full list of monitor plugins.",
                 )
             except Exception as exc:
-                import traceback
-
-                logging.warning(traceback.format_exception(exc))
                 logging.warning(
                     f"Unable to load manager plugin '{plugin_name}': {exc}",
                 )

--- a/landscape/client/manager/service.py
+++ b/landscape/client/manager/service.py
@@ -45,6 +45,9 @@ class ManagerService(LandscapeService):
                     "See `example.conf` for a full list of monitor plugins.",
                 )
             except Exception as exc:
+                import traceback
+
+                logging.warning(traceback.format_exception(exc))
                 logging.warning(
                     f"Unable to load manager plugin '{plugin_name}': {exc}",
                 )

--- a/landscape/client/manager/tests/test_scriptexecution.py
+++ b/landscape/client/manager/tests/test_scriptexecution.py
@@ -713,7 +713,8 @@ class RunScriptTests(LandscapeTest):
 
     def test_custom_script_tempdir(self):
         """
-        If the user provides a script execution tempdir, it is used.
+        If the user provides a script execution tempdir, it is used for the
+        script file.
         """
 
         tempdir = tempfile.TemporaryDirectory()
@@ -738,7 +739,8 @@ class RunScriptTests(LandscapeTest):
 
     def test_custom_script_attachment_tempdir(self):
         """
-        If the user provides a custom script attachment tempdir, it is used.
+        If the user provides a custom script tempdir, it is used for the
+        script attachments.
         """
         tempdir = tempfile.TemporaryDirectory()
         self.plugin.client.config.script_attachment_tempdir = tempdir


### PR DESCRIPTION
## Context

Adding a configuration option to set the working directory for script execution improves the CIS hardening experience. There is a "noexec on /tmp" rule that Landscape typically violates by requiring executables (scripts) in `/tmp`.

## Manual testing

### Client

Include the following in your `client.conf`:

```ini
script_tempdir = /var/custom-tempdir
manager_plugins = ScriptExecution
script_users = landscape,ALL
```

Set up your custom dir for script execution by the `landscape` user:

```sh
sudo mkdir -p /var/custom-tempdir
sudo chown landscape:landscape /var/custom-tempdir
sudo chmod 700 /var/custom-tempdir
```

Run the client:

```sh
sudo scripts/landscape-client -c landscape-client.conf
```

### Optional: verify file creation in the expected directory

I used `inotify` to verify that the scripts and attachments appeared in my temp directory:

```sh
sudo apt install inotify-tools
sudo inotifywait -m -e create --format '%w%f' /var/custom-tempdir

# Verify that /tmp is not being used by Landscape for scripts
inotifywait -m -e create --format '%w%f' /tmp
```

### Server

Run server (any server) and register your client. Configure a script that uses an attachment. A simple test is to `cat $LANDSCAPE_ATTACHMENTS/<my attachment>` from your script.

Run the script as the `landscape` user. It should succeed. You should be able to see your attachment in the output.

### Extra credit

Repeat, but without the configuration for the tempdirs. Landscape should again use `/tmp`.