### PR TITLE
fix: bump codecov upload version and add secret token

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,4 +12,6 @@ jobs:
       - run: make depends-ci
       - run: make coverage TRIAL=/usr/bin/trial3
       - name: upload
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Attempted fix for the currently broken-by-rate-limiting codecov upload workflow.