### PR TITLE
Remove dist-utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help:  ## Print help about available targets
 
 .PHONY: depends
 depends:
-	sudo apt update && sudo apt-get -y install python3-configobj python3-coverage python3-distutils-extra\
+	sudo apt update && sudo apt-get -y install python3-configobj python3-coverage \
 		python3-flake8 python3-mock python3-netifaces python3-pip python3-pycurl python3-twisted\
 		net-tools
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 XSBC-Original-Maintainer: Landscape Team <landscape-team@canonical.com>
 Build-Depends: debhelper (>= 11), po-debconf, libdistro-info-perl,
-               dh-python, python3-dev, python3-distutils-extra,
+               dh-python, python3-dev,
                lsb-release, gawk, net-tools,
                python3-apt, python3-twisted, python3-configobj,
                python3-pycurl, python3-netifaces, python3-yaml,

--- a/landscape/lib/versioning.py
+++ b/landscape/lib/versioning.py
@@ -1,5 +1,5 @@
 """Helpers for dealing with software versioning."""
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 
 def is_version_higher(version1, version2):
@@ -19,7 +19,7 @@ def is_version_higher(version1, version2):
     """
     version1 = version1.decode("ascii")
     version2 = version2.decode("ascii")
-    return StrictVersion(version1) >= StrictVersion(version2)
+    return Version(version1) >= Version(version2)
 
 
 def sort_versions(versions):
@@ -28,7 +28,7 @@ def sort_versions(versions):
     @param version: a C{list} of C{bytes} describing a version.
     """
     strict_versions = sorted(
-        [StrictVersion(version.decode("ascii")) for version in versions],
+        [Version(version.decode("ascii")) for version in versions],
         reverse=True,
     )
     return [


### PR DESCRIPTION
Remove distutils so we can update to Core24 base for the snap, which uses Python3.12 in which distutils are not supported.