### PR TITLE
build: create release tracks for core-22 & core-24

### DIFF
--- a/.github/workflows/update-release-branches.yml
+++ b/.github/workflows/update-release-branches.yml
@@ -1,0 +1,44 @@
+name: Update release branches
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-release-branches:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - branch: core-24
+            base: core24
+          - branch: core-22
+            base: core22
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Install dependencies
+        run: |
+          pip install --user jinja2-cli
+
+      - name: Update ${{ matrix.branch }} branch
+        run: |
+          # necessary otherwise git will crash & despair when we attempt to commit
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+
+          git fetch origin ${{ matrix.branch }}
+          git checkout ${{ matrix.branch }}
+          git merge -X theirs main
+
+          jinja2 snap/snapcraft.yaml.j2 -D base=${{ matrix.base }} > snap/snapcraft.yaml
+
+          git add --force snap/snapcraft.yaml
+          git commit -m "Update snapcraft.yaml" || true
+
+          git push origin ${{ matrix.branch }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ landscape_client.egg-info
 .pybuild
 venv
 .venv
+
+# templated, generate with `make snap-yaml`
+snap/snapcraft.yaml

--- a/README
+++ b/README
@@ -31,8 +31,8 @@ sudo apt update && sudo apt install landscape-client
 
 The Landscape Client generally runs as a combination of the `root` and
 `landscape` users.  It is possible to disable the administrative features of
-Landscape and run only the monitoring parts of it without using the `root`
-user at all.
+Landscape and run only the monitoring parts without using the `root` user at
+all.
 
 If you wish to use the Landscape Client in this way, it's recommended that you
 perform these steps immediately after installing the landscape-client package.

--- a/README
+++ b/README
@@ -6,6 +6,7 @@
 Add our beta PPA to get the latest updates to the landscape-client package
 
 #### Add repo to an Ubuntu series
+
 ```
 sudo add-apt-repository ppa:landscape/self-hosted-beta
 ```
@@ -101,14 +102,21 @@ python3 -m twisted.trial landscape.client.broker.tests.test_client.BrokerClientT
 ### Building the Landscape Client snap
 
 First, you need to ensure that you have the appropriate tools installed:
+
 ```
 $ sudo snap install snapcraft --classic
 $ lxd init --auto
 ```
 
 There are various make targets defined to assist in the lifecycle of
-building and testing the snap.  To simply build the snap with the minimum
-of debug information displayed:
+building and testing the snap. Generate the snap's `snapcraft.yaml` file:
+
+```console
+$ make snap-yaml
+``
+
+To simply build the snap with the minimum of debug information displayed:
+
 ```
 $ make snap
 ```
@@ -116,6 +124,7 @@ $ make snap
 If you would prefer to see more information displayed showing the progress
 of the build, and would like to get dropped into a debug shell within the
 snap container in the event of an error:
+
 ```
 $ make snap-debug
 ```
@@ -128,22 +137,26 @@ $ snap install yq
 ```
 
 To install the resulting snap:
+
 ```
 $ make snap-install
 ```
 
 To remove a previously installed snap:
+
 ```
 $ make snap-remove
 ```
 
 To clean the intermediate files as well as the snap itself from the local
 build environment:
+
 ```
 $ make snap-clean
 ```
 
 To enter into a shell environment within the snap container:
+
 ```
 $ make snap-shell
 ```
@@ -156,6 +169,7 @@ https://snapcraft.io/docs/creating-your-developer-account
 
 After obtaining and confirming your store credentials, you then need to
 log in using the snapcraft tool:
+
 ```
 $ snapcraft login
 ```
@@ -164,15 +178,18 @@ Since snapcraft version 7.x and higher, the credentials are stored in the
 gnome keyring on your local workstation.  If you are building in an
 environment without a GUI (e.g. in a multipass or lxc container), you
 will need to install the gnome keyring tools:
+
 ```
 $ sudo apt install gnome-keyring
 ```
 
 You will then need to initialze the default keyring as follows:
+
 ```
 $ dbus-run-session -- bash
 $ gnome-keyring-daemon --unlock
 ```
+
 The gnome-keyring-daemon will prompt you (without a prompt) to type in
 the initial unlock password (typically the same password for the account
 you are using - if you are using the default multipass or lxc "ubuntu"
@@ -183,16 +200,20 @@ Type the login password and hit <ENTER> followed by <CTRL>+D to end
 the input.
 
 At this point, you should be able to log into snapcraft:
+
 ```
 $ snapcraft login
 ```
+
 You will be prompted for your UbuntuOne email address, password and,
 if set up this way, your second factor for authentication.  If you
 are successful, you should be able to query your login credentials
 with:
+
 ```
 $ snapcraft whoami
 ```
+
 A common mistake that first-time users of this process might make
 is that after running the gnome-keyring-daemon command, they will
 exit the dbus session shell.  Do NOT do that.  Do all subsequent
@@ -208,6 +229,11 @@ logged into the store.
 
 ### Automatic Builds and Releases
 
-The latest version of landscape-client snap will be built from the most recent commit and
-published to the `latest/edge` channel via [a recipe on launchpad](https://launchpad.net/~landscape/landscape-client/+snap/core-dev).
-Other channels are promoted and released manually.
+The landscape-client snap is automatically built from the most recent commit on the release branches and published to the `<base>/edge` channel of the respective core base:
+
+| Core Base | Edge Channel | Build Recipe                                                               |
+|-----------|--------------|----------------------------------------------------------------------------|
+| 24        | `24/edge`    | [core-24](https://launchpad.net/~landscape/landscape-client/+snap/core-24) |
+| 22        | `22/edge`    | [core-22](https://launchpad.net/~landscape/landscape-client/+snap/core-22) |
+
+Other channels (`<base>/beta`, `<base>/candidate`, `<base>/stable`) are promoted and released manually.

--- a/snap/snapcraft.yaml.j2
+++ b/snap/snapcraft.yaml.j2
@@ -21,6 +21,7 @@ platforms:
   armhf:
   ppc64el:
   s390x:
+  riscv64:
 {% else %}
 architectures:
   - build-on: [amd64]

--- a/snap/snapcraft.yaml.j2
+++ b/snap/snapcraft.yaml.j2
@@ -1,5 +1,7 @@
+{%- set python_version = "3.12" if base == "core24" else "3.10" -%}
+
 name: landscape-client
-base: core22
+base: {{ base }}
 version: '24.12'
 icon: snap/gui/landscape-logo-256.png
 website: https://ubuntu.com/landscape
@@ -11,6 +13,15 @@ description: |
   Landscape account.
 
 grade: stable
+
+{%- if base == "core24" %}
+platforms:
+  amd64:
+  arm64:
+  armhf:
+  ppc64el:
+  s390x:
+{% else %}
 architectures:
   - build-on: [amd64]
   - build-on: [arm64]
@@ -18,11 +29,13 @@ architectures:
   - build-on: [ppc64el]
   - build-on: [s390x]
   - build-on: [riscv64]
+{% endif -%}
+
 confinement: strict
 
 environment:
   LANDSCAPE_CLIENT_SNAP: 1
-  PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$SNAP/lib/python3.10/site-packages:$PYTHONPATH
+  PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$SNAP/lib/python{{ python_version }}/site-packages:$PYTHONPATH
 
 plugs:
   var-lib-ubuntu-advantage-status:


### PR DESCRIPTION
As discussed, the `main` branch will now have a template `snapcraft.yaml` which will be used to generate different yaml files for the core24 & core22 snaps.

Sample CI runs on my fork:

Core 24:

- [CI run](https://github.com/st3v3nmw/landscape-client/actions/runs/16889324813/job/47844834477)
- [Generated snapcraft.yaml](https://github.com/st3v3nmw/landscape-client/blob/core-24/snap/snapcraft.yaml)

Core 22:

- [CI run](https://github.com/st3v3nmw/landscape-client/actions/runs/16889324813/job/47844834494)
- [Generated snapcraft.yaml](https://github.com/st3v3nmw/landscape-client/blob/core-22/snap/snapcraft.yaml)

---

To create the commit, a git user is required but the `checkout` action [1] doesn't set the user so we have to set it up manually. We're attributing the commit to whoever triggered the workflow run [2]. 

[1] https://github.com/actions/checkout/issues/13
[2] https://github.com/orgs/community/discussions/40405#discussioncomment-7355735