### PR TITLE
feat: activity to detach pro

### DIFF
--- a/landscape/client/manager/promanagement.py
+++ b/landscape/client/manager/promanagement.py
@@ -7,17 +7,12 @@ from landscape.client.manager.plugin import (
 )
 from landscape.client.manager.ubuntuproinfo import get_ubuntu_pro_info
 from landscape.lib.uaclient import (
-    AttachProError,
-    DetachProError,
+    ProManagementError,
     attach_pro,
     detach_pro,
 )
 
 import json
-
-
-ATTACH_PRO_FAILURE = 2
-DETACH_PRO_FAILURE = 3
 
 
 class ProManagement(ManagerPlugin):
@@ -74,12 +69,8 @@ class ProManagement(ManagerPlugin):
     def _respond_failure(self, failure, opid):
         try:
             failure.raiseException()
-        except AttachProError as e:
-            code = ATTACH_PRO_FAILURE
-            return self._respond(FAILED, str(e), opid, code)
-        except DetachProError as e:
-            code = DETACH_PRO_FAILURE
-            return self._respond(FAILED, str(e), opid, code)
+        except ProManagementError as e:
+            return self._respond(FAILED, str(e), opid)
         except Exception:
             return self._respond(FAILED, str(failure), opid)
 

--- a/landscape/client/manager/tests/test_promanagement.py
+++ b/landscape/client/manager/tests/test_promanagement.py
@@ -5,11 +5,10 @@ from landscape.client.manager.promanagement import ProManagement
 from landscape.client.tests.helpers import LandscapeTest, ManagerHelper
 
 from landscape.lib.uaclient import (
-    AttachProError,
     ConnectivityException,
     ContractAPIException,
-    DetachProError,
     LockHeldException,
+    ProManagementError,
 )
 
 
@@ -106,7 +105,7 @@ class ProManagementTests(LandscapeTest):
         with mock.patch(
             "landscape.client.manager.promanagement.detach_pro"
         ) as mock_attach:
-            mock_attach.side_effect = DetachProError
+            mock_attach.side_effect = ProManagementError
             result = self._send_detach()
 
         def got_result(r):
@@ -117,8 +116,7 @@ class ProManagementTests(LandscapeTest):
                         "type": "operation-result",
                         "operation-id": 123,
                         "status": FAILED,
-                        "result-text": DetachProError.message,
-                        "result-code": 3,
+                        "result-text": ProManagementError.message,
                     },
                 ],
             )
@@ -135,7 +133,7 @@ class ProManagementTests(LandscapeTest):
         with mock.patch(
             "landscape.client.manager.promanagement.attach_pro"
         ) as mock_attach:
-            mock_attach.side_effect = AttachProError
+            mock_attach.side_effect = ProManagementError
             result = self._send_attach()
 
         def got_result(r):
@@ -146,8 +144,7 @@ class ProManagementTests(LandscapeTest):
                         "type": "operation-result",
                         "operation-id": 123,
                         "status": FAILED,
-                        "result-text": AttachProError.message,
-                        "result-code": 2,
+                        "result-text": ProManagementError.message,
                     },
                 ],
             )
@@ -176,7 +173,6 @@ class ProManagementTests(LandscapeTest):
                         "operation-id": 123,
                         "status": FAILED,
                         "result-text": ConnectivityException.message,
-                        "result-code": 2,
                     },
                 ],
             )
@@ -205,7 +201,6 @@ class ProManagementTests(LandscapeTest):
                         "operation-id": 123,
                         "status": FAILED,
                         "result-text": ContractAPIException.message,
-                        "result-code": 2,
                     },
                 ],
             )
@@ -234,7 +229,6 @@ class ProManagementTests(LandscapeTest):
                         "operation-id": 123,
                         "status": FAILED,
                         "result-text": LockHeldException.message,
-                        "result-code": 2,
                     },
                 ],
             )

--- a/landscape/lib/tests/test_uaclient.py
+++ b/landscape/lib/tests/test_uaclient.py
@@ -2,12 +2,11 @@ from dataclasses import dataclass
 from unittest import TestCase, mock
 
 from landscape.lib.uaclient import (
-    AttachProError,
     ConnectivityException,
     ContractAPIException,
-    DetachProError,
     InvalidTokenException,
     LockHeldException,
+    ProManagementError,
     ProNotAttachedError,
     attach_pro,
     detach_pro,
@@ -88,12 +87,12 @@ class TestUAClientWrapper(TestCase):
     def test_attach_pro_ubuntu_pro_error(self, mock_options):
         mock_options.side_effect = UbuntuProError
 
-        with self.assertRaises(AttachProError):
+        with self.assertRaises(ProManagementError):
             attach_pro("fake-token")
 
     def test_attach_pro_no_uaclient(self):
         with mock.patch("landscape.lib.uaclient.uaclient", None):
-            with self.assertRaises(AttachProError):
+            with self.assertRaises(ProManagementError):
                 attach_pro("fake-token")
 
     @mock.patch("landscape.lib.uaclient.FullTokenAttachOptions")
@@ -148,12 +147,12 @@ class TestUAClientWrapper(TestCase):
         mock_is_attached.return_value = FakeIsAttached(is_attached=True)
         mock_detach.side_effect = UbuntuProError
 
-        with self.assertRaises(DetachProError):
+        with self.assertRaises(ProManagementError):
             detach_pro()
 
     def test_detach_pro_no_uaclient(self):
         with mock.patch("landscape.lib.uaclient.uaclient", None):
-            with self.assertRaises(DetachProError):
+            with self.assertRaises(ProManagementError):
                 detach_pro()
 
     def test_detach_not_attached(self):

--- a/landscape/lib/uaclient.py
+++ b/landscape/lib/uaclient.py
@@ -27,46 +27,44 @@ except ImportError:  # pragma: no cover
     uaclient = None
 
 
-class AttachProError(Exception):
-    message = "Could not attach pro."
+class ProManagementError(Exception):
+    message = "Error managing pro."
+
+    def __init__(self, message: str | None = None):
+        if message:
+            self.message = message
 
     def __str__(self):
         return self.message
 
 
-class ConnectivityException(AttachProError):
+class ConnectivityException(ProManagementError):
     message = "Not possible to connect to contracts service."
 
 
-class ContractAPIException(AttachProError):
+class ContractAPIException(ProManagementError):
     message = "Unexpected error in the contracts service interaction."
 
 
-class LockHeldException(AttachProError):
+class LockHeldException(ProManagementError):
     message = "Another client process is holding the lock on the machine."
 
 
-class InvalidTokenException(AttachProError):
+class InvalidTokenException(ProManagementError):
     message = "Invalid pro token provided."
 
 
-class DetachProError(Exception):
-    message = "Could not detach pro."
-
-    def __str__(self):
-        return self.message
-
-
-class ProNotAttachedError(DetachProError):
+class ProNotAttachedError(ProManagementError):
     message = "Pro is not attached on this machine."
+
+
+UACLIENT_ERROR_MESSAGE = "The ubuntu advantage library is not available or not up to date."  # noqa
 
 
 def get_pro_status():
     """Calls uaclient.status to get pro information."""
     if uaclient is None:
-        logging.warning(
-            "The ubuntu advantage library is not available or not up to date."
-        )
+        logging.warning(UACLIENT_ERROR_MESSAGE)
         return {}
     try:
         config = UAConfig()
@@ -82,10 +80,8 @@ def get_pro_status():
 def attach_pro(token):
     """Attaches a pro token to current machine."""
     if uaclient is None:
-        logging.warning(
-            "The ubuntu advantage library is not available or not up to date."
-        )
-        raise AttachProError
+        logging.warning(UACLIENT_ERROR_MESSAGE)
+        raise ProManagementError(UACLIENT_ERROR_MESSAGE)
 
     try:
         options = FullTokenAttachOptions(
@@ -102,15 +98,13 @@ def attach_pro(token):
     except LockHeldError:
         raise LockHeldException
     except UbuntuProError:
-        raise AttachProError
+        raise ProManagementError
 
 
 def detach_pro():
     if uaclient is None:
-        logging.warning(
-            "The ubuntu advantage library is not available or not up to date."
-        )
-        raise DetachProError
+        logging.warning(UACLIENT_ERROR_MESSAGE)
+        raise ProManagementError(UACLIENT_ERROR_MESSAGE)
 
     try:
         result = is_attached()
@@ -119,4 +113,4 @@ def detach_pro():
 
         detach()
     except UbuntuProError:
-        raise DetachProError
+        raise ProManagementError


### PR DESCRIPTION
## Manual testing
- Checkout `david-mclain:lndeng-2988-activity-for-detaching-pro` on server
- Register client w/ server
- Attach pro to client container
- Run `curl -X POST http://landscape-server-jammy.com/api/v2/detach-token -H "Authorization: Bearer $JWT" -d '{"computer_ids": [<computer_id>]}'`
- Wait for activity to run and verify pro gets detached
- Test without pro attached as well