### PR TITLE
build: add build deb package action

### DIFF
--- a/.github/workflows/build-jammy.yaml
+++ b/.github/workflows/build-jammy.yaml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.get-reference.outputs.ref }}
+          submodules: true
 
       - name: Install build dependencies
         run: sudo apt update && sudo apt install -y debhelper po-debconf libdistro-info-perl dh-python python3-dev python3-distutils-extra lsb-release gawk net-tools python3-apt python3-twisted python3-configobj python3-pycurl locales-all devscripts

--- a/.github/workflows/build-jammy.yaml
+++ b/.github/workflows/build-jammy.yaml
@@ -1,0 +1,74 @@
+name: Build Jammy
+
+on:
+
+  # Enable manual run against a specific ref
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build from (branch name, tag, commit SHA, etc.)"
+        required: false
+        default: ''
+
+  # Enable use from other workflows
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to build from (branch name, tag, commit SHA, etc.)"
+        required: true
+        type: string
+
+  # Run on any tag pushes
+  push:
+    tags:
+      - "**"
+
+jobs:
+  build-jammy:
+    name: Build Jammy
+    runs-on: ubuntu-22.04
+
+    steps:
+      # Get the reference to build from, if provided.
+      - name: Get reference to build from
+        id: get-reference
+        run: echo "ref=${{ github.event.inputs.ref || github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
+
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.get-reference.outputs.ref }}
+
+      - name: Install build dependencies
+        run: sudo apt update && sudo apt install -y debhelper po-debconf libdistro-info-perl dh-python python3-dev python3-distutils-extra lsb-release gawk net-tools python3-apt python3-twisted python3-configobj python3-pycurl locales-all devscripts
+
+      - name: Build .deb
+        run: |
+          mkdir -p ../source-build
+          mkdir -p ../deb-build
+
+          make releasetarball origtarball
+          rm -r sdist/
+
+          debuild --no-lintian -S -sa --no-sign
+          cp ../landscape-client_* ../source-build
+
+          # If we use this to automatically make releases or upload to the PPA, we should enable checks.
+          DEB_BUILD_OPTIONS=nocheck debuild -b --no-sign
+          cp ../landscape-client_*.orig.tar.gz ../deb-build
+          cp ../landscape-*.*deb ../deb-build
+
+      - name: Upload source build
+        uses: actions/upload-artifact@v4
+        with:
+          name: source-build
+          path: ./source-build/
+
+      - name: Upload deb build
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-build
+          path: ./deb-build/
+
+      - run: |
+          echo "::notice::Built from ref: ${{ steps.get-reference.outputs.ref }}"

--- a/.github/workflows/build-jammy.yaml
+++ b/.github/workflows/build-jammy.yaml
@@ -52,12 +52,16 @@ jobs:
           rm -r sdist/
 
           debuild --no-lintian -S -sa --no-sign
-          cp ../landscape-client_* ../source-build
+          cp ../landscape-client_* ../source-build/
 
           # If we use this to automatically make releases or upload to the PPA, we should enable checks.
           DEB_BUILD_OPTIONS=nocheck debuild -b --no-sign
-          cp ../landscape-client_*.orig.tar.gz ../deb-build
-          cp ../landscape-*.*deb ../deb-build
+          cp ../landscape-client_*.orig.tar.gz ../deb-build/
+          cp ../landscape-*.*deb ../deb-build/
+
+          # Artifact upload steps do not allow relative paths
+          mv ../source-build/ ./
+          mv ../deb-build/ ./
 
       - name: Upload source build
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ build:
 .PHONY: check
 check: TRIAL_ARGS=
 check: build
-	PYTHONPATH=$(PYTHONPATH):$(CURDIR) LC_ALL=C $(PYTHON) $(TRIAL) --unclean-warnings $(TRIAL_ARGS) landscape
+	@if ! echo "$$DEB_BUILD_OPTIONS" | grep -qw nocheck; then \
+		PYTHONPATH=$(PYTHONPATH):$(CURDIR) LC_ALL=C $(PYTHON) $(TRIAL) --unclean-warnings $(TRIAL_ARGS) landscape; \
+	fi
 
 .PHONY: coverage
 coverage:

--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,3 @@
 version=4
 opts=filenamemangle=s/.+\/v?(\d\S+)\.tar\.gz/landscape-client-$1\.tar\.gz/ \
-  https://github.com/CanonicalLtd/landscape-client/tags .*/?(\d{2}\.\d{2})\.tar\.gz
+  https://github.com/Canonical/landscape-client/tags .*/?(\d{2}\.\d{2})\.tar\.gz


### PR DESCRIPTION
generates the source and deb builds for easier testing and release.

Test by running this action on your fork and installing the resulting deb package. 
