### PR TITLE
fix: add python3-packaging dependency to landscape-client

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,31 +3,42 @@ Section: admin
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 XSBC-Original-Maintainer: Landscape Team <landscape-team@canonical.com>
-Build-Depends: debhelper (>= 11), po-debconf, libdistro-info-perl,
-               dh-python, python3-dev, python3-setuptools,
-               lsb-release, gawk, net-tools, python3-packaging,
-               python3-apt, python3-twisted, python3-configobj,
-               python3-pycurl, python3-netifaces, python3-yaml,
-               ubuntu-advantage-tools, locales-all, python3-dbus
+Build-Depends: debhelper (>= 11), dh-python, po-debconf,
+  gawk,
+  libdistro-info-perl,
+  locales-all,
+  lsb-release,
+  python3-apt,
+  python3-configobj,
+  python3-dbus,
+  python3-dev,
+  python3-packaging,
+  python3-pycurl,
+  python3-netifaces,
+  python3-setuptools,
+  python3-twisted,
+  python3-yaml,
+  net-tools,
+  ubuntu-advantage-tools
 Standards-Version: 4.4.0
 Homepage: https://github.com/CanonicalLtd/landscape-client
 
 Package: landscape-common
 Architecture: any
 Depends: ${python3:Depends}, ${misc:Depends}, ${extra:Depends},
-         python3-twisted,
-         python3-configobj,
-         python3-apt,
-         ca-certificates,
-         python3-gdbm,
-         python3-netifaces,
-         lsb-release,
-         adduser,
-         bc,
-         lshw,
-         libpam-modules,
-         python3-setuptools,
-         ubuntu-pro-client (>= 27.14~)
+  adduser,
+  bc,
+  ca-certificates,
+  libpam-modules,
+  lsb-release,
+  lshw,
+  python3-apt,
+  python3-configobj,
+  python3-gdbm,
+  python3-netifaces,
+  python3-twisted,
+  python3-setuptools,
+  ubuntu-pro-client (>= 27.14~)
 Description: Landscape administration system client - Common files
  Landscape is a web-based tool for managing Ubuntu systems. This
  package is necessary if you want your machine to be managed in a
@@ -40,11 +51,12 @@ Description: Landscape administration system client - Common files
 Package: landscape-client
 Architecture: any
 Depends: ${python3:Depends}, ${misc:Depends}, ${extra:Depends},
-         ${shlibs:Depends},
-         landscape-common (= ${binary:Version}),
-         python3-pycurl,
-	 python3-dbus,
-	 python3-yaml
+  ${shlibs:Depends},
+  landscape-common (= ${binary:Version}),
+  python3-pycurl,
+  python3-dbus,
+  python3-packaging,
+  python3-yaml
 Description: Landscape administration system client
  Landscape is a web-based tool for managing Ubuntu systems. This
  package is necessary if you want your machine to be managed in a


### PR DESCRIPTION
Many Ubuntu systems come with `python3-packaging` pre-installed, but not all of them do. It's better to explicitly list this dependency.

Note: I also tidied up the other dependencies listed in the control file. Please make sure I did not accidentally delete something.