### PR TITLE
build: run TiCS static analysis on noble

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 6 * * 0'  # Run at 6:00a (arbitrary) to avoid peak activity on runners
 jobs:
   TICS:
-    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
+    runs-on: [self-hosted, linux, amd64, tiobe, noble]
     steps:
       - name: Checkout master branch
         uses: actions/checkout@v4


### PR DESCRIPTION
On jammy, `coverage` requires `coverage[toml]` to read the `pyproject.toml`. This extension isn't in the Ubuntu archive for jammy, so rather than work around layering it on top of the archive-provided dependencies, this change simply bumps the runner up to noble, where the extension is included.