### PR TITLE
chore: update snap version to 26.02

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PYDOCTOR ?= pydoctor
 TXT2MAN ?= txt2man
 PYTHON ?= python3
 SNAPCRAFT = SNAPCRAFT_BUILD_INFO=1 snapcraft
+SNAP_BASE ?= core24
 TRIAL ?= -m landscape.lib.run_tests
 TRIAL_ARGS ?=
 
@@ -116,7 +117,7 @@ etags:
 
 .PHONY: snap-yaml
 snap-yaml:
-	jinja2 snap/snapcraft.yaml.j2 -D base=core24 > snap/snapcraft.yaml
+	jinja2 snap/snapcraft.yaml.j2 -D base=$(SNAP_BASE) > snap/snapcraft.yaml
 
 .PHONY: snap-install
 snap-install:
@@ -137,7 +138,7 @@ snap-shell: snap-install
 
 .PHONY: snap-debug
 snap-debug: snap-yaml
-	$(SNAPCRAFT) -v --debug
+	$(SNAPCRAFT) pack -v --debug
 
 .PHONY: snap-clean
 snap-clean: snap-remove
@@ -147,7 +148,7 @@ snap-clean: snap-remove
 
 .PHONY: snap
 snap: snap-yaml
-	$(SNAPCRAFT)
+	$(SNAPCRAFT) pack
 
 # TICS expects coverage info to be in ./coverage/.coverage
 .PHONY: prepare-tics-analysis

--- a/snap/snapcraft.yaml.j2
+++ b/snap/snapcraft.yaml.j2
@@ -3,9 +3,10 @@
 
 name: landscape-client
 base: {{ base }}
-version: '24.12'
+version: '26.02'
 icon: snap/gui/landscape-logo-256.png
 website: https://ubuntu.com/landscape
+license: GPL-2.0-only
 summary: Client for the Canonical systems management product Landscape
 description: |
   Landcape is a web-based tool for managing Ubuntu systems. This snap, or the
@@ -147,6 +148,7 @@ parts:
       - ubuntu-advantage-tools
     override-stage: |
       craftctl default
+
       # Copy the scripts over
       mkdir -p ${SNAPCRAFT_PRIME}/usr/bin/
       cp -r ${SNAPCRAFT_PART_SRC}/scripts/. ${SNAPCRAFT_PRIME}/usr/bin/
@@ -157,5 +159,6 @@ parts:
       - logrotate
     override-prime: |
       craftctl default
+
       cp ${SNAPCRAFT_PART_SRC}/debian/landscape-client.logrotate ${SNAPCRAFT_PRIME}/etc/logrotate.conf
       sed -i 's/systemctl kill --signal=USR1 --kill-who=main/snapctl restart/' ${SNAPCRAFT_PRIME}/etc/logrotate.conf


### PR DESCRIPTION
This updates the snap version to match the latest deb. I'll work on the core 26 base snap soon-ish.