### PR TITLE
fix: restore tests for amd64v3

### DIFF
--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -702,9 +702,11 @@ class PackageReporterAptTest(LandscapeTest):
         self.reporter.os_release_filename = self.makeFile(SAMPLE_OS_RELEASE)
 
         # Undetermined arch
-        self.facade.set_arch("")
+        with mock.patch(
+            "landscape.lib.apt.package.facade.AptFacade.get_arch", return_value=None
+        ):
+            result = self.reporter.fetch_hash_id_db()
 
-        result = self.reporter.fetch_hash_id_db()
         logging_mock.assert_called_once_with(
             "Couldn't determine which hash=>id database to use: "
             "unknown dpkg architecture",

--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -703,7 +703,8 @@ class PackageReporterAptTest(LandscapeTest):
 
         # Undetermined arch
         with mock.patch(
-            "landscape.lib.apt.package.facade.AptFacade.get_arch", return_value=None
+            "landscape.lib.apt.package.facade.AptFacade.get_arch",
+            return_value="",
         ):
             result = self.reporter.fetch_hash_id_db()
 

--- a/landscape/client/package/tests/test_taskhandler.py
+++ b/landscape/client/package/tests/test_taskhandler.py
@@ -180,10 +180,11 @@ class PackageTaskHandlerTest(LandscapeTest):
         self.handler.os_release_filename = self.makeFile(SAMPLE_OS_RELEASE)
 
         # Undetermined arch
-        self.facade.set_arch(None)
-
-        # Go!
-        result = self.handler.use_hash_id_db()
+        with patch(
+            "landscape.lib.apt.package.facade.AptFacade.get_arch",
+            return_value=None
+        ):
+            result = self.handler.use_hash_id_db()
 
         # The failure should be properly logged
         logging_mock.assert_called_with(

--- a/landscape/client/package/tests/test_taskhandler.py
+++ b/landscape/client/package/tests/test_taskhandler.py
@@ -182,7 +182,7 @@ class PackageTaskHandlerTest(LandscapeTest):
         # Undetermined arch
         with patch(
             "landscape.lib.apt.package.facade.AptFacade.get_arch",
-            return_value=None
+            return_value="",
         ):
             result = self.handler.use_hash_id_db()
 

--- a/landscape/lib/apt/package/facade.py
+++ b/landscape/lib/apt/package/facade.py
@@ -487,8 +487,6 @@ class AptFacade:
 
         Setting multiple architectures isn't supported.
         """
-        if architecture is None:
-            architecture = ""
         # From oneiric and onwards Architectures is used to set which
         # architectures can be installed, in case multiple architectures
         # are supported. We force it to be single architecture, until we

--- a/landscape/lib/apt/package/tests/test_facade.py
+++ b/landscape/lib/apt/package/tests/test_facade.py
@@ -901,7 +901,7 @@ class AptFacadeTest(
     def test_set_arch_none(self):
         """
         C{None} cannot be passed to C{set_arch()}. This was previously allowed for
-        compatibility with C{SmartFacade}, which has been removed. 
+        compatibility with C{SmartFacade}, which has been removed.
         """
         with self.assertRaises(TypeError):
             self.facade.set_arch(None)

--- a/landscape/lib/apt/package/tests/test_facade.py
+++ b/landscape/lib/apt/package/tests/test_facade.py
@@ -898,15 +898,13 @@ class AptFacadeTest(
         self.facade.set_arch("i386")
         self.assertEqual("i386", self.facade.get_arch())
 
-    def test_get_set_arch_none(self):
+    def test_set_arch_none(self):
         """
-        If C{None} is passed to C{set_arch()}, the architecture is set
-        to "", since it can't be set to C{None}. This is to ensure
-        compatibility with C{SmartFacade}, and the architecture should
-        be set to C{None} in tests only.
+        C{None} cannot be passed to C{set_arch()}. This was previously allowed for
+        compatibility with C{SmartFacade}, which has been removed. 
         """
-        self.facade.set_arch(None)
-        self.assertEqual("", self.facade.get_arch())
+        with self.assertRaises(TypeError):
+            self.facade.set_arch(None)
 
     def test_set_arch_get_packages(self):
         """


### PR DESCRIPTION
This is blocking the 26.04 archive release for landscape-client because these tests fail on amd64v3, which means the package cannot build. The tests that were failing were for edge cases that should never occur in practice, and they were causing segmentation faults with amd64v3's optimized instructions. The tests have been modified to explicitly mock those edge cases.

I am triggering a launchpad build on my test PPA to see if the builds for amd64v3 go through properly, I will open the PR for review once that succeeds. 

https://launchpad.net/~joey-mucci/+archive/ubuntu/resolute-test-2/+sourcepub/18177769/+listing-archive-extra