### PR TITLE
build: release 26.02.2 for jammy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+landscape-client (26.02.2-0landscape0) jammy; urgency=medium
+
+  * fix: restore tests for amd64v3
+  * fix: use github API releases page for uscan watch
+  * fix: add deterministic sub-process generation for flaky tests
+
+ -- Joey Mucci <joseph.mucci@canonical.com>  Thu, 19 Mar 2026 14:46:10 +0000
+
 landscape-client (26.02.1-0landscape0) jammy; urgency=medium
 
   * fix: restore functionality and tests for python 3.14

--- a/landscape/__init__.py
+++ b/landscape/__init__.py
@@ -1,6 +1,6 @@
 DEBIAN_REVISION = ""
-UPSTREAM_VERSION = "26.02.1"
-PYTHON_VERSION = "26.02.1"
+UPSTREAM_VERSION = "26.02.2"
+PYTHON_VERSION = "26.02.2"
 VERSION = f"{UPSTREAM_VERSION}{DEBIAN_REVISION}"
 
 # The minimum server API version that all Landscape servers are known to speak


### PR DESCRIPTION
We need a new release with the amd64v3 fixes for the archive