### PR TITLE
fix: correct string formatting for ubuntu release upgrader log

### DIFF
--- a/landscape/client/package/reporter.py
+++ b/landscape/client/package/reporter.py
@@ -339,9 +339,7 @@ class PackageReporter(PackageTaskHandler):
                 and any(x.startswith(RELEASE_UPGRADER_PATTERN) for x in args)
                 and uid == UID_ROOT
             ):
-                logging.info(
-                    f"Found ubuntu-release-upgrader running (pid: {pid})"
-                )
+                logging.info(f"Found ubuntu-release-upgrader running (pid: {pid})")
                 return True
         return False
 

--- a/landscape/client/package/reporter.py
+++ b/landscape/client/package/reporter.py
@@ -340,8 +340,7 @@ class PackageReporter(PackageTaskHandler):
                 and uid == UID_ROOT
             ):
                 logging.info(
-                    "Found ubuntu-release-upgrader running (pid: %d)",
-                    pid,
+                    f"Found ubuntu-release-upgrader running (pid: {pid})"
                 )
                 return True
         return False


### PR DESCRIPTION
`pid` is a string here, since it's returned by `os.path.basename`. We can't format it as an `int`. See the `Traceback` error in the tests for the [build log](https://launchpadlibrarian.net/852329787/buildlog_ubuntu-resolute-amd64.landscape-client_26.02.2-0landscape0~ppa2_BUILDING.txt.gz). 

Manual testing: Run the tests from this branch (with Python 3.14 if possible) and ensure there are no failures or other weird occurrences in the output. Also make sure that this test passes without a traceback.

Note: This regression was introduced [here](https://github.com/canonical/landscape-client/pull/327/changes#diff-06a988ef39442411b82d07fddd3904df162538b28037e85567eb100be7c47c45R311-R314), I'm just taking it back to the way it was.