### PR TITLE
ci: add ppa deploy

### DIFF
--- a/.github/workflows/build-jammy.yaml
+++ b/.github/workflows/build-jammy.yaml
@@ -17,16 +17,26 @@ on:
         description: "Git ref to build from (branch name, tag, commit SHA, etc.)"
         required: true
         type: string
+    outputs:
+      debbuildid:
+        description: "ID of the deb build artifact"
+        value: ${{ jobs.build-jammy.outputs.debbuildid }}
+      sourcebuildid:
+        description: "ID of the source build artifact"
+        value: ${{ jobs.build-jammy.outputs.sourcebuildid }}
 
-  # Run on any tag pushes
+  # Run on any non-beta tag pushes (beta tags are for the PPA deploy workflow)
   push:
-    tags:
-      - "**"
+    tags-ignore:
+      - "[0-9][0-9].[0-9][0-9]-beta**"
 
 jobs:
   build-jammy:
     name: Build Jammy
     runs-on: ubuntu-22.04
+    outputs:
+      debbuildid: ${{ steps.upload-deb-build.outputs.artifact-id }}
+      sourcebuildid: ${{ steps.upload-source-build.outputs.artifact-id }}
 
     steps:
       # Get the reference to build from, if provided.
@@ -64,16 +74,20 @@ jobs:
           mv ../deb-build/ ./
 
       - name: Upload source build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
+        id: upload-source-build
         with:
           name: source-build
           path: ./source-build/
 
       - name: Upload deb build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
+        id: upload-deb-build
         with:
           name: deb-build
           path: ./deb-build/
 
       - run: |
           echo "::notice::Built from ref: ${{ steps.get-reference.outputs.ref }}"
+          echo "::notice::Deb build artifact ID: ${{ steps.upload-deb-build.outputs.artifact-id }}"
+          echo "::notice::Source build artifact ID: ${{ steps.upload-source-build.outputs.artifact-id }}"

--- a/.github/workflows/ppa-deploy.yaml
+++ b/.github/workflows/ppa-deploy.yaml
@@ -1,0 +1,67 @@
+name: PPA Deploy
+
+on:
+
+  # Enable manual run, must specify target PPA
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build from"
+        required: false
+        default: "main"
+      target-ppa:
+        description: "Target PPA for publishing"
+        required: true
+        default: "landscape/self-hosted-daily"
+
+  # Run on any beta tag pushes
+  push:
+    tags:
+      - "[0-9][0-9].[0-9][0-9]-beta**"
+
+jobs:
+  calculate-ppa:
+    runs-on: [self-hosted, noble, amd64]
+    outputs:
+      ppa: ${{ steps.calc.outputs.ppa }}
+    steps:
+      - name: Calculate target PPA
+        id: calc
+        run: |
+          PPA="${{ inputs.target-ppa || 'landscape/self-hosted-beta' }}"
+          echo "ppa=$PPA" >> "$GITHUB_OUTPUT"
+
+  build:
+    uses: ./.github/workflows/build-jammy.yaml
+    with:
+      ref: ${{ inputs.ref || 'main' }}
+
+  ppa-upload:
+    needs: [calculate-ppa, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install upload dependenies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dput devscripts
+
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.LAUNCHPAD_GPG_PRIVATE_KEY }}
+        run: echo "$GPG_PRIVATE_KEY" | gpg --batch --import --yes
+
+      - name: Download landscape-client source artifacts
+        uses: actions/download-artifact@v7
+        with:
+          artifact-ids: ${{ needs.build.outputs.sourcebuildid }}
+          path: .
+
+      - name: Sign the build
+        run: |
+          KEY_ID=$(gpg --list-secret-keys | grep -B 1 "landscape-server-bot" | head -n 1 | xargs)
+          debsign -k"$KEY_ID" ./*_source.changes
+
+      - name: Upload to PPA
+        run: |
+          TARGET_PPA="${{ needs.calculate-ppa.outputs.ppa }}"
+          dput ppa:$TARGET_PPA ./*_source.changes


### PR DESCRIPTION
We should automate beta releases for landscape-client to `self-hosted-beta` as per internal documentation

Successful run for refactored build jammy: https://github.com/canonical/landscape-client/actions/runs/24107083785

We can test the ppa-deploy on the first beta-release. The actual ppa-upload logic is copy-paste from server. As far as I am aware there is no other validation on the landscape-client deb artifact except for building, so that's the only prereq for a beta upload for now.