### PR TITLE
build: release 26.08~beta.1 for jammy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+landscape-client (26.08~beta.1-0landscape0) jammy; urgency=medium
+
+  * fix: correct string formatting for ubuntu release upgrader log
+  * fix: restore tests for amd64v3
+  * fix: data file permissions are too lax (LP: #2121558)
+  * fix: add deterministic sub-process generation for flaky tests
+
+ -- Joey Mucci <joseph.mucci@canonical.com>  Tue, 07 Apr 2026 18:28:24 -0400
+
 landscape-client (26.02.1-0landscape0) jammy; urgency=medium
 
   * fix: restore functionality and tests for python 3.14

--- a/landscape/__init__.py
+++ b/landscape/__init__.py
@@ -1,6 +1,6 @@
-DEBIAN_REVISION = ""
-UPSTREAM_VERSION = "26.02.1"
-PYTHON_VERSION = "26.02.1"
+DEBIAN_REVISION = "-0landscape0"
+UPSTREAM_VERSION = "26.08~beta.1"
+PYTHON_VERSION = "26.8b1"
 VERSION = f"{UPSTREAM_VERSION}{DEBIAN_REVISION}"
 
 # The minimum server API version that all Landscape servers are known to speak


### PR DESCRIPTION
This PR is to start our regular client beta release cadence and include the latest LP bug fix in a beta.