### PR TITLE
fix: snap builds & installation

### DIFF
--- a/.github/workflows/snap-builds.yml
+++ b/.github/workflows/snap-builds.yml
@@ -1,0 +1,46 @@
+name: Test Snap Builds
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'snap/**'
+      - 'setup*.py'
+      - 'snap-http/**'
+      - 'landscape/client/snap_http'
+      - 'scripts/**'
+      - '.github/workflows/snap-builds.yml'
+
+jobs:
+  test-snap-builds:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        base: ["core24", "core22"]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Generate snapcraft.yaml
+        run: |
+          pip install --user jinja2-cli
+          jinja2 snap/snapcraft.yaml.j2 -D base=${{ matrix.base }} > snap/snapcraft.yaml
+
+      - name: LXD setup
+        uses: canonical/setup-lxd@main
+
+      - name: Build snap
+        run: |
+          sudo snap install snapcraft --classic
+          snapcraft pack
+
+      - name: Install snap
+        run: sudo snap install --dangerous landscape-client_*.snap
+
+      - name: Smoke test
+        run: |
+          landscape-client.config --help
+          test -f /var/snap/landscape-client/common/etc/landscape-client.conf

--- a/setup_client.py
+++ b/setup_client.py
@@ -10,6 +10,7 @@ PACKAGES = [
     "landscape.client.monitor",
     "landscape.client.package",
     "landscape.client.snap_http",
+    "landscape.client.snap_http.api",
     "landscape.client.upgraders",
     "landscape.client.user",
 ]

--- a/snap/snapcraft.yaml.j2
+++ b/snap/snapcraft.yaml.j2
@@ -110,23 +110,20 @@ parts:
     build-packages:
       - gawk
       - libdistro-info-perl
+      - locales-all
       - lsb-release
       - net-tools
       - po-debconf
       - python3-apt
       - python3-configobj
+      - python3-dbus
       - python3-dev
+      - python3-netifaces
+      - python3-pycurl
       - python3-setuptools
       - python3-twisted
-      - python3-pycurl
-      - python3-netifaces
       - python3-yaml
       - ubuntu-advantage-tools
-      - locales-all
-      - python3-dbus
-    override-build: |
-      make build
-      craftctl default
     stage-packages:
       - adduser
       - bc
@@ -139,12 +136,13 @@ parts:
       - python3
       - python3-apt
       - python3-configobj
+      - python3-dbus
       - python3-gdbm
       - python3-netifaces
+      - python3-pkg-resources
       - python3-pycurl
-      - python3-twisted
       - python3-setuptools
-      - python3-dbus
+      - python3-twisted
       - ubuntu-advantage-tools
     override-stage: |
       craftctl default


### PR DESCRIPTION
Installing the landscape-client snap was failing in two ways.

First, the `configure` hook crashed with this error because `python3-pkg-resources` was missing from `stage-packages`:

```console
$ sudo snap install --dangerous landscape-client_*.snap
error: cannot perform the following tasks:
- Run configure hook of "landscape-client" snap if present (run hook "configure": 
-----
Traceback (most recent call last):
  File "/snap/landscape-client/x1/meta/hooks/configure", line 6, in <module>
    from landscape.client.deployment import Configuration
  File "/snap/landscape-client/x1/lib/python3.12/site-packages/landscape/client/deployment.py", line 11, in <module>
    from twisted.logger import globalLogBeginner
  File "/snap/landscape-client/x1/usr/lib/python3/dist-packages/twisted/logger/__init__.py", line 93, in <module>
    from ._flatten import extractField
  File "/snap/landscape-client/x1/usr/lib/python3/dist-packages/twisted/logger/_flatten.py", line 15, in <module>
    from ._interfaces import LogEvent
  File "/snap/landscape-client/x1/usr/lib/python3/dist-packages/twisted/logger/_interfaces.py", line 10, in <module>
    from zope.interface import Interface
  File "/snap/landscape-client/x1/usr/lib/python3/dist-packages/zope/__init__.py", line 1, in <module>
    __import__('pkg_resources').declare_namespace(__name__)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'pkg_resources'
-----)
```

Second, a stale `api.py` was being packed into the snap instead of the current `api/` sub-package. This is because the snap-http submodule refactored `snap_http/api.py` into a proper sub-package (`snap_http/api/`), but `setup_client.py` was never updated to include `landscape.client.snap_http.api` so `setuptools` silently skipped it during the build.

This fixes both issues and adds a CI workflow that builds and installs the snap on both `core22` and `core24` to catch regressions of this kind going forward.

Related: #426