### PR TITLE
build: release 26.08~beta.1.1 for jammy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-landscape-client (26.08~beta.1.1-0landscape0) jammy; urgency=medium
+landscape-client (26.08~beta.2-0landscape0) jammy; urgency=medium
 
   * fix: snap builds & installation
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+landscape-client (26.08~beta.1.1-0landscape0) jammy; urgency=medium
+
+  * fix: snap builds & installation
+
+ -- Joey Mucci <joseph.mucci@canonical.com>  Fri, 10 Apr 2026 18:00:56 -0400
+
 landscape-client (26.08~beta.1-0landscape0) jammy; urgency=medium
 
   * fix: correct string formatting for ubuntu release upgrader log

--- a/landscape/__init__.py
+++ b/landscape/__init__.py
@@ -1,6 +1,6 @@
 DEBIAN_REVISION = "-0landscape0"
-UPSTREAM_VERSION = "26.08~beta.1"
-PYTHON_VERSION = "26.8b1"
+UPSTREAM_VERSION = "26.08~beta.1.1"
+PYTHON_VERSION = "26.8b1.1"
 VERSION = f"{UPSTREAM_VERSION}{DEBIAN_REVISION}"
 
 # The minimum server API version that all Landscape servers are known to speak

--- a/landscape/__init__.py
+++ b/landscape/__init__.py
@@ -1,6 +1,6 @@
 DEBIAN_REVISION = "-0landscape0"
-UPSTREAM_VERSION = "26.08~beta.1.1"
-PYTHON_VERSION = "26.8b1.1"
+UPSTREAM_VERSION = "26.08~beta.2"
+PYTHON_VERSION = "26.8b2"
 VERSION = f"{UPSTREAM_VERSION}{DEBIAN_REVISION}"
 
 # The minimum server API version that all Landscape servers are known to speak


### PR DESCRIPTION
We need another beta release because the last one was broken and consumers of our self-hosted-beta PPA are experiencing interruptions in their CI. Also, if it makes sense for this to be `beta.1-0landscape1` instead let me know. 