### PR TITLE
fix: disconnect connectors on error paths to prevent socket leak (LP: #2147687)

### DIFF
--- a/landscape/client/broker/server.py
+++ b/landscape/client/broker/server.py
@@ -161,6 +161,12 @@ class BrokerServer:
 
         @param name: The name of the client, such a C{monitor} or C{manager}.
         """
+        # disconnect old connector if it exists:
+        old_remote_client = self._registered_clients.get(name)
+        if old_remote_client is not None:
+            old_connector = self._connectors.pop(old_remote_client)
+            if old_connector is not None:
+                old_connector.disconnect()
         connector_class = self.connectors_registry.get(name)
         connector = connector_class(self._reactor, self._config)
 

--- a/landscape/client/broker/tests/test_server.py
+++ b/landscape/client/broker/tests/test_server.py
@@ -191,6 +191,50 @@ class BrokerServerTest(LandscapeTest):
         result = self.broker.register_client("test")
         return result.addCallback(assert_registered)
 
+    def test_register_client_disconnects_existing_connector(self):
+        """
+        The L{BrokerServer.register_client} method cleans up any existing
+        connector instances for the same component by popping them from the
+        registry and calling their C{disconnect()} method before installing the
+        new connector.
+        """
+
+        class StaleConnector:
+            def __init__(self):
+                self.disconnect_called = False
+
+            def disconnect(self):
+                self.disconnect_called = True
+
+        # Client that should be disconnected when a new
+        # connector with the same name is registered
+        stale_connector = StaleConnector()
+        old_client = FakeClient()
+        self.broker._registered_clients["test"] = old_client
+        self.broker._connectors[old_client] = stale_connector
+
+        # Another client that should not be disconnected
+        safe_connector = StaleConnector()
+        safe_client = FakeClient()
+        self.broker._registered_clients["other"] = safe_client
+        self.broker._connectors[safe_client] = safe_connector
+
+        def assert_cleaned_up(ignored):
+            self.assertTrue(stale_connector.disconnect_called)
+            self.assertFalse(safe_connector.disconnect_called)
+            self.assertNotEqual(
+                self.broker.get_connector("test"),
+                stale_connector,
+            )
+            self.assertEqual(
+                self.broker.get_connector("other"),
+                safe_connector,
+            )
+
+        self.broker.connectors_registry = {"test": FakeCreator}
+        result = self.broker.register_client("test")
+        return result.addCallback(assert_cleaned_up)
+
     def test_stop_clients(self):
         """
         The L{BrokerServer.stop_clients} method calls the C{exit} method

--- a/landscape/client/manager/tests/test_usermanager.py
+++ b/landscape/client/manager/tests/test_usermanager.py
@@ -1,8 +1,14 @@
 import os
 from unittest.mock import Mock, patch
 
+from twisted.internet.defer import fail
+
 from landscape.client.manager.plugin import FAILED, SUCCEEDED
-from landscape.client.manager.usermanager import RemoteUserManagerConnector, UserManager
+from landscape.client.manager.usermanager import (
+    RemoteUserManagerConnector,
+    RemoteUserMonitorConnector,
+    UserManager,
+)
 from landscape.client.monitor.usermonitor import UserMonitor
 from landscape.client.tests.helpers import LandscapeTest, ManagerHelper
 from landscape.client.user.provider import UserManagementError
@@ -119,6 +125,50 @@ class UserOperationsMessagingTest(UserGroupTestBase):
         )
 
         result.addCallback(handle_callback)
+        return result
+
+    def test_message_dispatch_disconnects_on_fail(self):
+        """
+        When L{UserManager._message_dispatch} experiences a failure while
+        performing an operation, the underlying
+        C{RemoteUserMonitorConnector.disconnect()} method is still reliably
+        executed.
+        """
+
+        class CallTracker:
+            called = False
+
+        original_disconnect = RemoteUserMonitorConnector.disconnect
+
+        def mock_disconnect(conn_self, *args, **kwargs):
+            CallTracker.called = True
+            return original_disconnect(conn_self, *args, **kwargs)
+
+        self.patch(RemoteUserMonitorConnector, "disconnect", mock_disconnect)
+
+        self.setup_environment(
+            users=[("jdoe", "x", 1000, 1000, "JD", "/home/jdoe", "/bin/sh")],
+            groups=[("users", "x", 1000, ["jdoe"])],
+            shadow_file=self.shadow_file,
+        )
+
+        message = {
+            "type": "add-user",
+            "operation-id": 1,
+            "username": "jdoe",
+        }
+
+        # Override the perform_operation handler to fail intentionally
+        failure = fail(RuntimeError("Injected test failure"))
+        self.plugins[1]._perform_operation = Mock(return_value=failure)
+
+        result = self.plugins[1]._message_dispatch(message)
+
+        def assert_disconnect(ignored):
+            self.assertTrue(CallTracker.called)
+
+        result = self.assertFailure(result, RuntimeError)
+        result.addBoth(assert_disconnect)
         return result
 
     def test_add_user_event_utf8(self):

--- a/landscape/client/manager/usermanager.py
+++ b/landscape/client/manager/usermanager.py
@@ -91,11 +91,15 @@ class UserManager(ManagerPlugin):
             self._user_monitor = user_monitor
             return user_monitor.detect_changes()
 
+        def disconnect(result):
+            user_monitor_connector.disconnect()
+            return result
+
         result = user_monitor_connector.connect()
         result.addCallback(detect_changes)
         result.addCallback(self._perform_operation, message)
         result.addCallback(self._send_changes, message)
-        result.addCallback(lambda x: user_monitor_connector.disconnect())
+        result.addBoth(disconnect)
         return result
 
     def _perform_operation(self, result, message):

--- a/landscape/client/monitor/tests/test_usermonitor.py
+++ b/landscape/client/monitor/tests/test_usermonitor.py
@@ -5,7 +5,7 @@ from twisted.internet.defer import fail
 
 import landscape.client.monitor.usermonitor
 from landscape.client.amp import ComponentPublisher
-from landscape.client.manager.usermanager import UserManager
+from landscape.client.manager.usermanager import RemoteUserManagerConnector, UserManager
 from landscape.client.monitor.usermonitor import RemoteUserMonitorConnector, UserMonitor
 from landscape.client.tests.helpers import LandscapeTest, MonitorHelper
 from landscape.client.user.tests.helpers import FakeUserProvider
@@ -532,6 +532,45 @@ class UserMonitorTest(LandscapeTest):
         result.addCallback(lambda remote: remote.detect_changes(1001))
         result.addCallback(got_result)
         result.addCallback(lambda x: connector.disconnect())
+        return result
+
+    def test_detect_changes_disconnects_on_fail(self):
+        """
+        When L{UserMonitor.detect_changes} fails during the data fetch phase,
+        the underlying C{RemoteUserManagerConnector.disconnect()} method is
+        still reliably executed via addBoth.
+        """
+
+        class CallTracker:
+            called = False
+
+        original_disconnect = RemoteUserManagerConnector.disconnect
+
+        def mock_disconnect(self, *args, **kwargs):
+            CallTracker.called = True
+            return original_disconnect(self, *args, **kwargs)
+
+        self.patch(RemoteUserManagerConnector, "disconnect", mock_disconnect)
+        self.broker_service.message_store.set_accepted_types(["users"])
+        self.monitor.add(self.plugin)
+
+        # Force the authentic IPC socket to return an AMP error,
+        # simulating failure
+        failure = fail(RuntimeError("Injected test failure"))
+        self.user_manager.get_locked_usernames = Mock(return_value=failure)
+
+        connector = RemoteUserMonitorConnector(self.reactor, self.config)
+        result = connector.connect()
+        result.addCallback(lambda remote: remote.detect_changes())
+
+        def assert_disconnect(ignored):
+            self.assertTrue(CallTracker.called)
+
+        # The detect_changes call returns the RPC deferred which swallows the
+        # errback internally into a SUCCESS of None due to
+        # `result.addErrback(lambda f: self._detect_changes([], operation_id))`.
+        result.addBoth(lambda x: connector.disconnect())
+        result.addBoth(assert_disconnect)
         return result
 
     def test_detect_changes_clears_user_provider_if_flag_file_exists(self):

--- a/landscape/client/monitor/usermonitor.py
+++ b/landscape/client/monitor/usermonitor.py
@@ -104,7 +104,7 @@ class UserMonitor(MonitorPlugin):
 
             result = user_manager_connector.connect()
             result.addCallback(get_locked_usernames)
-            result.addCallback(disconnect)
+            result.addBoth(disconnect)
             result.addCallback(self._detect_changes, operation_id)
             result.addErrback(lambda f: self._detect_changes([], operation_id))
         return result

--- a/landscape/client/tests/test_watchdog.py
+++ b/landscape/client/tests/test_watchdog.py
@@ -1120,6 +1120,36 @@ class DaemonBrokerTest(DaemonTestBase):
         result.addCallback(self.assertTrue)
         return result
 
+    def test_is_running_disconnects_on_fail(self):
+        """
+        When L{Daemon.is_running} experiences a failure while pinging the
+        remote, the underlying connector's C{disconnect()} method is still
+        reliably executed.
+        """
+
+        class FakeRemote:
+            def ping(self):
+                return fail(RuntimeError("Simulated ping timeout/error"))
+
+        class FakeConnector:
+            def __init__(self):
+                self.disconnect_called = False
+
+            def connect(self, *args, **kwargs):
+                return succeed(FakeRemote())
+
+            def disconnect(self):
+                self.disconnect_called = True
+
+        fake_con = FakeConnector()
+        self.daemon._connector = fake_con
+
+        def assert_disconnect(ignored):
+            self.assertTrue(fake_con.disconnect_called)
+
+        result = self.daemon.is_running()
+        return self.assertFailure(result, RuntimeError).addBoth(assert_disconnect)
+
 
 class WatchDogOptionsTest(LandscapeTest):
     def setUp(self):

--- a/landscape/client/watchdog.py
+++ b/landscape/client/watchdog.py
@@ -183,9 +183,9 @@ class Daemon:
         @see: L{RemoteLandscapeComponentCreator.connect}.
         """
 
-        def disconnect(ignored):
+        def disconnect(result):
             self._connector.disconnect()
-            return True
+            return result
 
         connected = self._connector.connect(
             self.max_retries,
@@ -193,7 +193,7 @@ class Daemon:
             quiet=True,
         )
         connected.addCallback(lambda remote: getattr(remote, name)())
-        connected.addCallback(disconnect)
+        connected.addBoth(disconnect)
         connected.addErrback(lambda x: False)
         return connected
 


### PR DESCRIPTION
## Description:

Connector `disconnect()` was only called on the success path via `addCallback`, meaning any failure mid-chain left the socket connector open. Over long periods of operation, this caused a slow but steady FD leak, eventually exhausting the process's file descriptor limit with `Errno 24: Too many open files`.

## Changes:
* `usermanager.py`: Changed `addCallback` to `addBoth` for `disconnect`, ensuring cleanup on both success and error paths.
* `usermonitor.py`: Same fix as `usermanager.py`
* `watchdog.py`: Same fix as `usermanager.py`
* `server.py`: Disconnect the existing connector if a client re-registers using the same name

## Launchpad Bug:

https://bugs.launchpad.net/landscape-client/+bug/2147687