### PR TITLE
fix(snap): make url options consistent with landscape-config

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#
+# This hook reads snap options set via `snap set`, writes them to
+# landscape-client.conf, and then unsets them.
+# The landscape-client.conf file is the single source of truth,
+# snap options are transient inputs only.
 
 import os
 import subprocess
@@ -6,13 +11,10 @@ import subprocess
 from landscape.client.deployment import Configuration
 
 
-def _snapctl(action, setting):
-    snapctl = subprocess.run(
-        ["snapctl", action, setting],
-        capture_output=True,
-        text=True,
-    )
+def _snapctl(*args):
+    snapctl = subprocess.run(["snapctl", *args], capture_output=True, text=True)
     return snapctl.stdout
+
 
 def update_ssl_cert(cert: str) -> str | None:
     cert_path = os.path.join(os.getenv("SNAP_COMMON"), "etc/ssl/certs")
@@ -28,12 +30,13 @@ def update_ssl_cert(cert: str) -> str | None:
 config = Configuration()
 config.load([])
 
+# Each entry in config_entries maps a snap option to a landscape
+# config key, with an optional mapping applied to the value.
 config_entries = [
-    # (snapctl key, landscape client config key, mapping function)
     ("account-name", "account_name", None),
     ("computer-title", "computer_title", None),
-    ("landscape-url", "url", lambda url: f"{url}/message-system"),
-    ("landscape-ping-url", "ping_url", lambda url: f"{url}/ping"),
+    ("url", "url", None),
+    ("ping-url", "ping_url", None),
     ("ssl-public-key", "ssl_public_key", update_ssl_cert),
     ("log-level", "log_level", None),
     ("script-users", "script_users", None),
@@ -51,8 +54,15 @@ config_entries = [
     ("cloud", "cloud", None),
 ]
 
+# Deprecated keys kept for backward compatibility.
+# New keys take precedence.
+legacy_config_entries = [
+    ("landscape-url", "url", lambda url: f"{url}/message-system"),
+    ("landscape-ping-url", "ping_url", lambda url: f"{url}/ping"),
+]
+
 changed = set()
-for snapctl_key, landscape_key, mapping_fn in config_entries:
+for snapctl_key, landscape_key, mapping_fn in [*legacy_config_entries, *config_entries]:
     value = _snapctl("get", snapctl_key).strip()
     if not value:
         # empty, value has not changed
@@ -66,7 +76,6 @@ for snapctl_key, landscape_key, mapping_fn in config_entries:
 
 config.write()
 
-# unset the values from snapctl so that in the next run
-#  we know what has changed
-# the landscape-client.conf file is still the main source of truth
-_snapctl("unset", " ".join(changed))
+# Unset changed keys so that on the next run we know what has changed.
+if changed:
+    _snapctl("unset", *changed)

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -6,14 +6,19 @@ _access_group=$(snapctl get access-group)
 _account=$(snapctl get account-name)
 _registration_key=$(snapctl get registration-key)
 _title=$(snapctl get computer-title)
-_url=$(snapctl get landscape-url)
+_url=$(snapctl get url)
+_ping_url=$(snapctl get ping-url)
 _log_level=$(snapctl get log-level)
 _script_users=$(snapctl get script-users)
 _manager_plugins=$(snapctl get manager-plugins)
 _monitor_plugins=$(snapctl get monitor-plugins)
 
 if [ -z "$_url" ]; then
-  _url="https://landscape.canonical.com"
+  _url="https://landscape.canonical.com/message-system"
+fi
+
+if [ -z "$_ping_url" ]; then
+  _ping_url="http://landscape.canonical.com/ping"
 fi
 
 if [ -z "$_log_level" ]; then
@@ -36,8 +41,8 @@ cat > "$CLIENT_CONF" << EOF
 [client]
 account_name = $_account
 computer_title = $_title
-url = ${_url}/message-system
-ping_url = ${_url}/ping
+url = $_url
+ping_url = $_ping_url
 log_level = $_log_level
 script_users = $_script_users
 manager_plugins = $_manager_plugins


### PR DESCRIPTION
[Field reported](https://chat.canonical.com/canonical/pl/ufqc5fgbo3fb9cdjeqnm5jin9c) that after running `snap set landscape-client ping-url=...` and other keys, only `ping-url` remained visible in `snap get` after restart with no configuration applied. Users naturally reach for `url` and `ping-url`, consistent with `landscape-client.conf`, the `landscape-config` CLI, and the snap's own `landscape-client.config`, but the hook only recognized `landscape-url` and `landscape-ping-url`, so those keys were never applied or cleared.

Additionally, the hook appended `/message-system` and `/ping` to the URL internally, meaning users following any existing documentation (which mostly uses full URLs) would end up with doubled paths in the configuration.

This PR renames the snap options to `url` and `ping-url`, and removes the internal path appending so full URLs are passed through directly. The old `landscape-url` and `landscape-ping-url` keys are kept as deprecated aliases so existing setups continue to work.

Related: https://github.com/canonical/landscape-documentation/pull/192

---

**1. After a fresh installation, the `default-configure` hook works as expected:**

```console
$ cat /var/snap/landscape-client/common/etc/landscape-client.conf
[client]
account_name =
computer_title =
url = https://landscape.canonical.com/message-system
ping_url = http://landscape.canonical.com/ping
log_level = info
script_users = ALL
manager_plugins = ProcessKiller,UserManager,ShutdownManager,HardwareInfo,KeystoneToken,SnapManager,SnapServicesManager,ScriptExecution,UbuntuProInfo
monitor_plugins = ActiveProcessInfo,ComputerInfo,LoadAverage,MemoryInfo,MountInfo,ProcessorInfo,Temperature,UserMonitor,RebootRequired,NetworkActivity,NetworkDevice,CPUUsage,SwiftUsage,CephUsage,ComputerTags,SnapServicesMonitor,CloudInit
```

**2. New `url` and `ping-url` keys are applied and cleared:**

```console
$ snap set landscape-client url=https://new.example.com/message-system ping-url=http://new.example.com/ping
$ snap get -d landscape-client
{}
$ grep -E "url|ping_url" /var/snap/landscape-client/common/etc/landscape-client.conf
url = https://new.example.com/message-system
ping_url = http://new.example.com/ping
```

**3. Legacy `landscape-url` & `landscape-ping-url` still work:**

```console
$ snap set landscape-client landscape-url=https://legacy-url.example.com
$ snap set landscape-client landscape-ping-url=http://legacy-ping.example.com
$ snap get -d landscape-client
{}
$ grep -E "url|ping_url" /var/snap/landscape-client/common/etc/landscape-client.conf
url = https://legacy-url.example.com/message-system
ping_url = http://legacy-ping.example.com/ping
```

**4. New key takes precedence over legacy key when both are set**

```console
$ snap set landscape-client landscape-url=https://old.example.com url=https://override.example.com/message-system
$ snap get -d landscape-client
{}
$ grep "url" /var/snap/landscape-client/common/etc/landscape-client.conf
url = https://override.example.com/message-system
```

**5. Unknown key persists (documented behavior)**

```console
$ snap set landscape-client some-url=https://typo.example.com
$ snap get -d landscape-client
{
        "some-url": "https://typo.example.com"
}
$ snap unset landscape-client some-url
$ snap get -d landscape-client
{}
```

`snapctl get` (used inside the hooks) has no equivalent to `snap get -d landscape-client` that returns the full config document, so the hook can only unset keys it recognizes. Unknown keys set by mistake will persist in snap options and have no effect. This behavior is [now documented](https://github.com/canonical/landscape-documentation/pull/192).