### PR TITLE
client: set User-Agent for ping requests

### DIFF
--- a/landscape/client/broker/ping.py
+++ b/landscape/client/broker/ping.py
@@ -43,6 +43,7 @@ except ImportError:
 from twisted.internet import defer
 from twisted.python.failure import Failure
 
+from landscape import VERSION
 from landscape.lib import bpickle
 from landscape.lib.fetch import fetch
 from landscape.lib.log import log_failure
@@ -69,7 +70,10 @@ class PingClient:
             and False otherwise.
         """
         if insecure_id is not None:
-            headers = {"Content-Type": "application/x-www-form-urlencoded"}
+            headers = {
+                "User-Agent": f"landscape-client/{VERSION}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            }
             data = urlencode({"insecure_id": insecure_id})
             page_deferred = defer.Deferred()
 

--- a/landscape/client/broker/tests/test_ping.py
+++ b/landscape/client/broker/tests/test_ping.py
@@ -1,5 +1,6 @@
 from twisted.internet.defer import fail
 
+from landscape import VERSION
 from landscape.client.broker.ping import PingClient, Pinger
 from landscape.client.broker.tests.helpers import ExchangeHelper
 from landscape.client.tests.helpers import LandscapeTest
@@ -66,7 +67,10 @@ class PingClientTest(LandscapeTest):
                 (
                     url,
                     True,
-                    {"Content-Type": "application/x-www-form-urlencoded"},
+                    {
+                        "User-Agent": f"landscape-client/{VERSION}",
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
                     "insecure_id=10",
                 ),
             ],


### PR DESCRIPTION
## Summary

Set an explicit `User-Agent` header for ping requests.

`exchange.py` already identifies itself using:

```python id="v4af8t"
User-Agent: landscape-client/{VERSION}
```

but `ping.py` currently falls back to the default PycURL/libcurl generated user-agent.

This results in inconsistent client identification across Landscape endpoints and may cause `/ping` requests to be filtered differently by reverse proxies or WAFs.

Use the same Landscape-specific `User-Agent` for ping requests to align behavior with `/message-system`.

## Testing

```bash id="bny9wq"
pytest landscape/client/broker/tests/test_ping.py
```
