### PR TITLE
feat(snap): add core26 support

### DIFF
--- a/.github/workflows/snap-builds.yml
+++ b/.github/workflows/snap-builds.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base: ["core24", "core22"]
+        base: ["core26", "core24", "core22"]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v6
@@ -35,7 +36,7 @@ jobs:
       - name: Build snap
         run: |
           sudo snap install snapcraft --classic
-          snapcraft pack
+          snapcraft pack --verbosity=debug
 
       - name: Install snap
         run: sudo snap install --dangerous landscape-client_*.snap

--- a/.github/workflows/update-release-branches.yml
+++ b/.github/workflows/update-release-branches.yml
@@ -11,6 +11,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - branch: core-26
+            base: core26
           - branch: core-24
             base: core24
           - branch: core-22

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYDOCTOR ?= pydoctor
 TXT2MAN ?= txt2man
 PYTHON ?= python3
 SNAPCRAFT = SNAPCRAFT_BUILD_INFO=1 snapcraft
-SNAP_BASE ?= core24
+SNAP_BASE ?= core26
 TRIAL ?= -m landscape.lib.run_tests
 TRIAL_ARGS ?=
 

--- a/README
+++ b/README
@@ -119,6 +119,12 @@ building and testing the snap. To generate the snap's `snapcraft.yaml` file:
 make snap-yaml
 ```
 
+By default this targets `core26`. To target a different base, pass `SNAP_BASE`:
+
+```shell
+make snap-yaml SNAP_BASE=core24
+```
+
 To simply build the snap with the minimum of debug information displayed:
 
 ```shell
@@ -237,6 +243,7 @@ The landscape-client snap is automatically built from the most recent commit on 
 
 | Core Base | Edge Channel | Build Recipe                                                               |
 |-----------|--------------|----------------------------------------------------------------------------|
+| 26        | `26/edge`    | [core-26](https://launchpad.net/~landscape/landscape-client/+snap/core-26) |
 | 24        | `24/edge`    | [core-24](https://launchpad.net/~landscape/landscape-client/+snap/core-24) |
 | 22        | `22/edge`    | [core-22](https://launchpad.net/~landscape/landscape-client/+snap/core-22) |
 

--- a/snap/snapcraft.yaml.j2
+++ b/snap/snapcraft.yaml.j2
@@ -1,9 +1,11 @@
 {# this is a template, generate the actual snapcraft.yaml with `make snap-yaml` #}
-{%- set python_version = "3.12" if base == "core24" else "3.10" -%}
+{%- set python_versions = {"core22": "3.10", "core24": "3.12", "core26": "3.14"} -%}
+{%- set python_version = python_versions[base] -%}
+{%- set supported_archs = ["amd64", "arm64", "armhf", "ppc64el", "s390x", "riscv64"] -%}
 
 name: landscape-client
 base: {{ base }}
-version: '26.02'
+version: '26.08'
 icon: snap/gui/landscape-logo-256.png
 website: https://ubuntu.com/landscape
 license: GPL-2.0-only
@@ -16,23 +18,17 @@ description: |
 
 grade: stable
 
-{%- if base == "core24" %}
-platforms:
-  amd64:
-  arm64:
-  armhf:
-  ppc64el:
-  s390x:
-  riscv64:
-{% else %}
+{%- if base == "core22" %}
 architectures:
-  - build-on: [amd64]
-  - build-on: [arm64]
-  - build-on: [armhf]
-  - build-on: [ppc64el]
-  - build-on: [s390x]
-  - build-on: [riscv64]
-{% endif -%}
+{%- for arch in supported_archs %}
+  - build-on: [{{ arch }}]
+{%- endfor %}
+{%- else %}
+platforms:
+{%- for arch in supported_archs %}
+  {{ arch }}:
+{%- endfor %}
+{%- endif %}
 
 confinement: strict
 
@@ -104,9 +100,17 @@ layout:
     bind: $SNAP_DATA/var/log/landscape
 
 parts:
+  python-runtime:
+    plugin: nil
+    stage-packages:
+      - python{{ python_version }}
+
   landscape-client:
+    after: [python-runtime]
     plugin: python
     source: .
+    override-build: |
+      pip install --target=${CRAFT_PART_INSTALL}/lib/python{{ python_version }}/site-packages .
     build-packages:
       - gawk
       - libdistro-info-perl
@@ -133,23 +137,27 @@ parts:
       - lsb-base
       - lsb-release
       - lshw
-      - python3
       - python3-apt
       - python3-configobj
       - python3-dbus
       - python3-gdbm
       - python3-netifaces
+      - python3-packaging
       - python3-pkg-resources
       - python3-pycurl
       - python3-setuptools
       - python3-twisted
       - ubuntu-advantage-tools
-    override-stage: |
+    override-prime: |
       craftctl default
 
       # Copy the scripts over
       mkdir -p ${SNAPCRAFT_PRIME}/usr/bin/
       cp -r ${SNAPCRAFT_PART_SRC}/scripts/. ${SNAPCRAFT_PRIME}/usr/bin/
+
+      # Rewrite shebangs to use the snap-local python3
+      sed -i '1s|#!/usr/bin/python3|#!/usr/bin/env python3|' ${SNAPCRAFT_PRIME}/usr/bin/landscape-*
+
   logrotate:
     plugin: nil
     source: .


### PR DESCRIPTION
This PR introduces `core26` support to the landscape-client snap. 

The `core26` base [no longer bundles a Python interpreter](https://forum.snapcraft.io/t/core26-bundled-python-changes/50178) hence the refactors in the `snapcraft.yaml` to [bundle a Python runtime with the snap](https://documentation.ubuntu.com/snapcraft/9.0/how-to/change-bases/change-from-core24-to-core26/#repackage-python) and use that instead of the interpreter previously bundled with the base. The standard `plugin: python` virtualenv-based build is also broken in core26, complaining that `ensurepip` is not available despite it being present, so this PR overrides build with a direct `pip install --target` similar to what we used to have last year: https://github.com/canonical/landscape-client/blob/30995b3c4abace0f89d17eaeba7ac8346ad4e43b/snap/snapcraft.yaml#L111-L113

The `#!/usr/bin/python3` shebangs in the primed scripts are also rewritten to `#!/usr/bin/env python3` so that script execution resolves to the snap's own bundled interpreter rather than the absent base one.

---

The snap is [building successfully](https://github.com/canonical/landscape-client/actions/runs/27683193051) across all 3 core bases we now support. And I've tested it against staging:

<img width="1327" height="1048" alt="image" src="https://github.com/user-attachments/assets/22e3edae-b5cc-414d-a1a9-b77650924d3e" />

<br/>

Lastly, the artefact size has increased a little, 15M on previous core24 builds to 18M now.. 19M on core26. The build isn't happy with `python3-minimal` and friends..