### PR TITLE
Add optional urllib HTTP backend as an alternative to pycurl (LP: #2159858)

### DIFF
--- a/landscape/client/broker/config.py
+++ b/landscape/client/broker/config.py
@@ -111,6 +111,12 @@ class BrokerConfiguration(Configuration):
             "--authenticated-attach-code",
             help="A one-time-use, Landscape server-generated code.",
         )
+        parser.add_argument(
+            "--http-client",
+            default="pycurl",
+            choices=["pycurl", "urllib"],
+            help="The HTTP client to use for server communication (pycurl or urllib).",
+        )
 
         return parser
 

--- a/landscape/client/broker/exchange.py
+++ b/landscape/client/broker/exchange.py
@@ -350,7 +350,7 @@ from twisted.internet.defer import Deferred, succeed
 
 from landscape import CLIENT_API, DEFAULT_SERVER_API, SERVER_API
 from landscape.lib.backoff import ExponentialBackoff
-from landscape.lib.fetch import HTTPCodeError, PyCurlError
+from landscape.lib.fetch import HTTPCodeError, TransportError
 from landscape.lib.format import format_delta
 from landscape.lib.hashlib import md5
 from landscape.lib.message import RESYNC, got_next_expected
@@ -639,7 +639,7 @@ class MessageExchange:
                     self._backoff_counter.increase()
 
             ssl_error = False
-            if isinstance(error, PyCurlError) and error.error_code == 60:
+            if isinstance(error, TransportError) and error.error_code == 60:
                 # The error returned is an SSL error, most likely the server
                 # is using a self-signed certificate. Let's fire a special
                 # event so that the GUI can display a nice message.

--- a/landscape/client/broker/service.py
+++ b/landscape/client/broker/service.py
@@ -58,6 +58,7 @@ class BrokerService(LandscapeService):
             self.reactor,
             config.url,
             config.ssl_public_key,
+            http_client=config.http_client,
         )
         self.message_store = get_default_message_store(
             self.persist,

--- a/landscape/client/broker/tests/test_exchange.py
+++ b/landscape/client/broker/tests/test_exchange.py
@@ -10,7 +10,7 @@ from landscape.client.broker.store import MessageStore
 from landscape.client.broker.tests.helpers import ExchangeHelper
 from landscape.client.broker.transport import FakeTransport
 from landscape.client.tests.helpers import DEFAULT_ACCEPTED_TYPES, LandscapeTest
-from landscape.lib.fetch import HTTPCodeError, PyCurlError
+from landscape.lib.fetch import HTTPCodeError, TransportError
 from landscape.lib.hashlib import md5
 from landscape.lib.persist import Persist
 from landscape.lib.schema import Int
@@ -1366,7 +1366,7 @@ class MessageExchangeTest(LandscapeTest):
 
         self.reactor.call_on("exchange-failed", failed_exchange)
         self.transport.responses.append(
-            PyCurlError(60, "Failed to communicate."),
+            TransportError(60, "Failed to communicate."),
         )
         self.exchanger.exchange()
         self.assertEqual([None], events)
@@ -1385,7 +1385,7 @@ class MessageExchangeTest(LandscapeTest):
 
         self.reactor.call_on("exchange-failed", failed_exchange)
         self.transport.responses.append(
-            PyCurlError(10, "Failed to communicate."),  # Not 60
+            TransportError(10, "Failed to communicate."),  # Not 60
         )
         self.exchanger.exchange()
         self.assertEqual([None], events)

--- a/landscape/client/broker/tests/test_transport.py
+++ b/landscape/client/broker/tests/test_transport.py
@@ -9,7 +9,7 @@ from landscape import VERSION
 from landscape.client.broker.transport import HTTPTransport
 from landscape.client.tests.helpers import LandscapeTest
 from landscape.lib import bpickle
-from landscape.lib.fetch import PyCurlError
+from landscape.lib.fetch import TransportError
 from landscape.lib.testing import LogKeeperHelper
 
 
@@ -167,7 +167,7 @@ class HTTPTransportTest(LandscapeTest):
         specified public key, then the client should immediately end
         the connection without uploading any message data.
         """
-        self.log_helper.ignore_errors(PyCurlError)
+        self.log_helper.ignore_errors(TransportError)
         r = DataCollectingResource()
         context_factory = DefaultOpenSSLContextFactory(BADPRIVKEY, BADPUBKEY)
         port = reactor.listenSSL(

--- a/landscape/client/broker/transport.py
+++ b/landscape/client/broker/transport.py
@@ -14,10 +14,11 @@ class HTTPTransport:
     @param pubkey: SSH public key used for secure communication.
     """
 
-    def __init__(self, reactor, url, pubkey=None):
+    def __init__(self, reactor, url, pubkey=None, http_client="pycurl"):
         self._reactor = reactor
         self._url = url
         self._pubkey = pubkey
+        self._http_client = http_client
 
     def get_url(self):
         """Get the URL of the remote message system."""
@@ -53,6 +54,7 @@ class HTTPTransport:
                 computer_id=computer_id,
                 exchange_token=exchange_token,
                 server_api=message_api.decode(),
+                http_client=self._http_client,
             )
         except Exception:
             return None
@@ -70,7 +72,7 @@ class HTTPTransport:
 class FakeTransport:
     """Fake transport for testing purposes."""
 
-    def __init__(self, reactor=None, url=None, pubkey=None):
+    def __init__(self, reactor=None, url=None, pubkey=None, http_client="pycurl"):
         self._pubkey = pubkey
         self.payloads = []
         self.responses = []

--- a/landscape/client/configuration.py
+++ b/landscape/client/configuration.py
@@ -798,6 +798,7 @@ def attempt_registration(
                 client_info,
                 config.url,
                 cainfo=config.ssl_public_key,
+                http_client=config.http_client,
             )
 
             break

--- a/landscape/client/exchange.py
+++ b/landscape/client/exchange.py
@@ -36,6 +36,7 @@ def exchange_messages(
     computer_id: str | None = None,
     exchange_token: bytes | None = None,
     server_api: str = SERVER_API.decode(),
+    http_client: str = "pycurl",
 ) -> ServerResponse:
     """Sends `payload` via HTTP(S) to `server_url`, parsing and returning the
     response.
@@ -47,6 +48,7 @@ def exchange_messages(
     :param computer_id: The computer ID to send the message as.
     :param exchange_token: Token included in the exchange to prove client
         identity.
+    :param http_client: The HTTP client to use ('pycurl' or 'urllib').
     """
     start_time = time.time()
     logging.debug(f"Sending payload:\n{pformat(payload)}")
@@ -64,7 +66,9 @@ def exchange_messages(
     if exchange_token:
         headers["X-Exchange-Token"] = exchange_token.decode()
 
-    curl = pycurl.Curl()
+    curl = None
+    if http_client == "pycurl":
+        curl = pycurl.Curl()
 
     try:
         response_bytes = fetch(
@@ -74,6 +78,7 @@ def exchange_messages(
             headers=headers,
             cainfo=cainfo,
             curl=curl,
+            http_client=http_client,
         )
     except Exception:
         logging.exception(f"Error contacting the server at {server_url}.")

--- a/landscape/client/monitor/tests/test_computerinfo.py
+++ b/landscape/client/monitor/tests/test_computerinfo.py
@@ -6,7 +6,7 @@ from twisted.internet.defer import fail, inlineCallbacks, succeed
 
 from landscape.client.monitor.computerinfo import METADATA_RETRY_MAX, ComputerInfo
 from landscape.client.tests.helpers import LandscapeTest, MonitorHelper
-from landscape.lib.fetch import HTTPCodeError, PyCurlError
+from landscape.lib.fetch import HTTPCodeError, TransportError
 from landscape.lib.fs import create_text_file
 from landscape.lib.machine_id import MACHINE_ID_SIZE, get_namespaced_machine_id
 
@@ -543,11 +543,11 @@ DISTRIB_NEW_UNEXPECTED_KEY=ooga
     def test_fetch_ec2_meta_data_no_cloud_api_max_retry(self):
         """
         L{_fetch_ec2_meta_data} returns C{None} when faced with no EC2 cloud
-        API service and reports the specific C{PyCurlError} upon message
+        API service and reports the specific C{TransportError} upon message
         exchange when L{_cloud_retries} equals C{METADATA_RETRY_MAX}.
         """
-        self.log_helper.ignore_errors(PyCurlError)
-        self.add_query_result("instance-id", PyCurlError(60, "pycurl error"))
+        self.log_helper.ignore_errors(TransportError)
+        self.add_query_result("instance-id", TransportError(60, "pycurl error"))
         plugin = ComputerInfo(fetch_async=self.fetch_func)
         plugin._cloud_retries = METADATA_RETRY_MAX
         result = yield plugin._fetch_ec2_meta_data()

--- a/landscape/client/registration.py
+++ b/landscape/client/registration.py
@@ -13,7 +13,7 @@ from typing import Any
 from landscape.client.broker.registration import Identity
 from landscape.client.exchange import exchange_messages
 from landscape.client.manager.ubuntuproinfo import get_ubuntu_pro_info
-from landscape.lib.fetch import HTTPCodeError, PyCurlError
+from landscape.lib.fetch import HTTPCodeError, TransportError
 from landscape.lib.machine_id import get_namespaced_machine_id
 from landscape.lib.network import get_fqdn
 from landscape.lib.vm_info import get_container_info, get_vm_info
@@ -81,6 +81,7 @@ def register(
     server_url: str,
     *,
     cainfo: str | None = None,
+    http_client: str = "pycurl",
 ) -> RegistrationInfo:
     """Sends a registration message to the server at `server_url`, returning
     registration info if successful.
@@ -90,7 +91,9 @@ def register(
     message = _create_message(client_info)
 
     try:
-        response = exchange_messages(message, server_url, cainfo=cainfo)
+        response = exchange_messages(
+            message, server_url, cainfo=cainfo, http_client=http_client
+        )
     except HTTPCodeError as e:
         if e.http_code == 404:
             # Most likely cause is that we are trying to speak to a server with
@@ -102,7 +105,22 @@ def register(
             ) from e
 
         raise  # Other exceptions are unexpected and should propagate.
-    except PyCurlError as e:
+    except TransportError as e:
+        # GnuTLS rejects certificate chains deeper than its hard-coded limit
+        # with error -101; pycurl surfaces this as error 35. There is no
+        # structured signal for it, so we match on the message text.
+        if e.error_code == 35 and (
+            "-101" in e.message or "constraint" in e.message.lower()
+        ):
+            raise RegistrationException(
+                "\nThe server certificate verification failed with a "
+                "GnuTLS depth limit / constraint error (-101).\n"
+                "This usually happens when the certificate chain is too "
+                "deep for GnuTLS.\n"
+                "You can try registering using the urllib HTTP client by "
+                "adding the --http-client urllib option.",
+            ) from e
+
         if e.error_code == 60:
             raise RegistrationException(
                 "\nThe server's SSL information is incorrect or fails "

--- a/landscape/client/tests/test_configuration.py
+++ b/landscape/client/tests/test_configuration.py
@@ -37,7 +37,7 @@ from landscape.client.environment import DIRECTORY_MODE, FILE_MODE, GROUP, USER
 from landscape.client.registration import RegistrationInfo
 from landscape.client.serviceconfig import ServiceConfigException
 from landscape.client.tests.helpers import LandscapeTest
-from landscape.lib.fetch import HTTPCodeError, PyCurlError
+from landscape.lib.fetch import HTTPCodeError, TransportError
 from landscape.lib.fs import read_binary_file
 from landscape.lib.persist import Persist
 from landscape.lib.testing import EnvironSaverHelper
@@ -1966,7 +1966,7 @@ registration_key = shared-secret
         mock_fetch,
         mock_print_text,
     ):
-        mock_fetch.side_effect = PyCurlError(60, "pycurl message")
+        mock_fetch.side_effect = TransportError(60, "pycurl message")
 
         config_filename = self.makeFile("", basename="final_config")
 

--- a/landscape/client/tests/test_exchange.py
+++ b/landscape/client/tests/test_exchange.py
@@ -59,6 +59,7 @@ class ExchangeMessagesTestCase(TestCase):
             },
             cainfo="mycainfo",
             curl=mock.ANY,
+            http_client="pycurl",
         )
         self.assertEqual(self.logging_mock.debug.call_count, 2)
         self.logging_mock.info.assert_called_once()

--- a/landscape/client/tests/test_registration.py
+++ b/landscape/client/tests/test_registration.py
@@ -8,7 +8,7 @@ from landscape.client.registration import (
     RegistrationException,
     register,
 )
-from landscape.lib.fetch import HTTPCodeError, PyCurlError
+from landscape.lib.fetch import HTTPCodeError, TransportError
 
 
 class RegisterTestCase(TestCase):
@@ -85,7 +85,10 @@ class RegisterTestCase(TestCase):
             computer_title="Test Computer",
         )
 
-        self.exchange_messages_mock.side_effect = PyCurlError(error_code=60, message="")
+        self.exchange_messages_mock.side_effect = TransportError(
+            error_code=60,
+            message="",
+        )
 
         with self.assertRaises(RegistrationException):
             register(client_info, "https://my-server.local/message-system")
@@ -100,9 +103,12 @@ class RegisterTestCase(TestCase):
             computer_title="Test Computer",
         )
 
-        self.exchange_messages_mock.side_effect = PyCurlError(error_code=61, message="")
+        self.exchange_messages_mock.side_effect = TransportError(
+            error_code=61,
+            message="",
+        )
 
-        with self.assertRaises(PyCurlError):
+        with self.assertRaises(TransportError):
             register(client_info, "https://my-server.local/message-system")
 
     def test_no_messages(self):
@@ -146,3 +152,24 @@ class RegisterTestCase(TestCase):
             register(client_info, "https://my-server.local/message-system")
 
         self.assertIn("Did not receive ID", str(exc_context.exception))
+
+    def test_exchange_pycurl_error_gnutls_depth_limit(self):
+        """If a pycurl error 35 with GnuTLS depth limit -101 occurs, it is caught
+        and a helpful RegistrationException is raised.
+        """
+        client_info = ClientRegistrationInfo(
+            access_group="",
+            account_name="testy",
+            computer_title="Test Computer",
+        )
+
+        self.exchange_messages_mock.side_effect = TransportError(
+            error_code=35,
+            message="server cert verify failed: -101",
+        )
+
+        with self.assertRaises(RegistrationException) as exc_context:
+            register(client_info, "https://my-server.local/message-system")
+
+        self.assertIn("GnuTLS depth limit", str(exc_context.exception))
+        self.assertIn("--http-client urllib", str(exc_context.exception))

--- a/landscape/lib/fetch.py
+++ b/landscape/lib/fetch.py
@@ -1,11 +1,20 @@
+import gzip
 import io
 import os
+import ssl
 import sys
+import time
+import urllib.error
+import urllib.request
+import zlib
 from argparse import ArgumentParser
 from logging import warning
 
 from twisted.internet.defer import DeferredList
 from twisted.internet.threads import deferToThread
+
+# Size of each body read from the urllib backend
+_READ_CHUNK_SIZE = 64 * 1024
 
 
 class FetchError(Exception):
@@ -24,7 +33,7 @@ class HTTPCodeError(FetchError):
         return f"<HTTPCodeError http_code={self.http_code:d}>"
 
 
-class PyCurlError(FetchError):
+class TransportError(FetchError):
     def __init__(self, error_code, message):
         self.error_code = error_code
         self._message = message
@@ -33,18 +42,178 @@ class PyCurlError(FetchError):
         return f"Error {self.error_code:d}: {self.message}"
 
     def __repr__(self):
-        return f"<PyCurlError args=({self.error_code:d}, '{self.message}')>"
+        return f"<TransportError args=({self.error_code:d}, '{self.message}')>"
 
     @property
     def message(self):
         return self._message
 
 
+# Backwards-compatible alias for external importers of landscape-lib that
+# referenced the old name. Deprecated: use TransportError instead.
+PyCurlError = TransportError
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """A redirect handler that stops urllib from following HTTP redirects."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _maybe_decompress(body, content_encoding):
+    """Decompress C{body} according to the given C{Content-Encoding} value."""
+    content_encoding = (content_encoding or "").lower()
+    if "gzip" in content_encoding:
+        return gzip.decompress(body)
+    if "deflate" in content_encoding:
+        try:
+            return zlib.decompress(body)
+        except zlib.error:
+            # some servers send raw DEFLATE (RFC 1951), not zlib-wrapped
+            return zlib.decompress(body, -zlib.MAX_WBITS)
+    return body
+
+
+def _fetch_urllib(
+    url,
+    post=False,
+    data="",
+    headers=None,
+    cainfo=None,
+    connect_timeout=30,
+    total_timeout=600,
+    insecure=False,
+    follow=True,
+    user_agent=None,
+    proxy=None,
+):
+    """Retrieve a URL using the stdlib urllib backend.
+
+    See L{fetch} for the meaning of the parameters. Failures are translated
+    into the same L{HTTPCodeError} and L{TransportError} exceptions raised by
+    the pycurl backend so that callers can handle both backends uniformly.
+    """
+    if isinstance(url, bytes):
+        url = url.decode("ascii")
+
+    if not isinstance(data, bytes):
+        data = data.encode("utf-8")
+
+    req = urllib.request.Request(
+        url,
+        data=data if post else None,
+        method="POST" if post else "GET",
+    )
+
+    req.add_header("Accept-Encoding", "gzip, deflate")
+
+    if headers:
+        for key, value in headers.items():
+            req.add_header(key, value)
+
+    if user_agent is not None:
+        if isinstance(user_agent, bytes):
+            user_agent = user_agent.decode("ascii")
+        req.add_header("User-Agent", user_agent)
+
+    ctx = None
+    if url.startswith("https:"):
+        ctx = ssl.create_default_context()
+        if insecure:
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+        elif cainfo:
+            if not os.access(cainfo, os.R_OK):
+                warning(
+                    "SSL certificate provided is not accessible by landscape "
+                    + "client. Please place in directory that is readable such "
+                    + "as '/etc/ssl/certs'",
+                )
+            else:
+                ctx.load_verify_locations(cafile=cainfo)
+
+    handlers = []
+    if proxy is not None:
+        if isinstance(proxy, bytes):
+            proxy = proxy.decode("ascii")
+        handlers.append(
+            urllib.request.ProxyHandler({"http": proxy, "https": proxy}),
+        )
+
+    if not follow:
+        handlers.append(_NoRedirectHandler())
+
+    if ctx is not None:
+        handlers.append(urllib.request.HTTPSHandler(context=ctx))
+
+    opener = urllib.request.build_opener(*handlers)
+
+    # Mirror pycurl's LOW_SPEED_LIMIT/TIME: abort on sustained low throughput
+    # (urllib's socket timeout only catches a fully silent connection)
+    low_speed_limit = 1  # bytes/sec, mirrors pycurl's LOW_SPEED_LIMIT
+    try:
+        with opener.open(req, timeout=connect_timeout) as response:
+            chunks = []
+            bytes_since_sample = 0
+            low_speed_elapsed = 0.0
+            last_sample = time.monotonic()
+            while True:
+                chunk = response.read(_READ_CHUNK_SIZE)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                bytes_since_sample += len(chunk)
+                interval = time.monotonic() - last_sample
+                if interval < 1:
+                    continue  # sample throughput once a second
+                if bytes_since_sample < interval * low_speed_limit:
+                    low_speed_elapsed += interval
+                    if low_speed_elapsed > total_timeout:
+                        raise TransportError(
+                            28,  # CURLE_OPERATION_TIMEDOUT
+                            f"Transfer speed stayed below {low_speed_limit} "
+                            f"byte/s for more than {total_timeout} seconds",
+                        )
+                else:
+                    low_speed_elapsed = 0.0
+                last_sample = time.monotonic()
+                bytes_since_sample = 0
+            body = b"".join(chunks)
+            http_code = response.getcode()
+            content_encoding = response.headers.get("Content-Encoding")
+    except urllib.error.HTTPError as e:
+        body = _maybe_decompress(e.read(), e.headers.get("Content-Encoding"))
+        raise HTTPCodeError(e.code, body)
+    except urllib.error.URLError as e:
+        # Map urllib/ssl failures onto the libcurl error codes that callers
+        # (e.g. registration.register) already branch on, so error handling
+        # is uniform across the pycurl and urllib backends.
+        reason = e.reason
+        if isinstance(reason, ssl.SSLCertVerificationError):
+            raise TransportError(60, str(reason)) from e  # CURLE_SSL_CACERT
+        elif isinstance(reason, ssl.SSLError):
+            raise TransportError(35, str(reason)) from e  # CURLE_SSL_CONNECT_ERROR
+        else:
+            raise TransportError(7, str(e)) from e  # CURLE_COULDNT_CONNECT
+    except TransportError:
+        raise  # deliberate low-speed abort, propagate as is
+    except Exception as e:
+        raise TransportError(0, str(e)) from e  # unknown/unclassified error
+
+    body = _maybe_decompress(body, content_encoding)
+
+    if http_code != 200:
+        raise HTTPCodeError(http_code, body)
+
+    return body
+
+
 def fetch(
     url,
     post=False,
     data="",
-    headers={},
+    headers=None,
     cainfo=None,
     curl=None,
     connect_timeout=30,
@@ -53,6 +222,7 @@ def fetch(
     follow=True,
     user_agent=None,
     proxy=None,
+    http_client="pycurl",
 ):
     """Retrieve a URL and return the content.
 
@@ -70,7 +240,23 @@ def fetch(
     @param follow: If True, follow HTTP redirects (default True).
     @param user_agent: The user-agent to set in the request.
     @param proxy: The proxy url to use for the request.
+    @param http_client: The HTTP backend to use ('pycurl' or 'urllib').
     """
+    if http_client == "urllib":
+        return _fetch_urllib(
+            url,
+            post=post,
+            data=data,
+            headers=headers,
+            cainfo=cainfo,
+            connect_timeout=connect_timeout,
+            total_timeout=total_timeout,
+            insecure=insecure,
+            follow=follow,
+            user_agent=user_agent,
+            proxy=proxy,
+        )
+
     import pycurl
 
     if not isinstance(data, bytes):
@@ -130,7 +316,7 @@ def fetch(
     try:
         curl.perform()
     except pycurl.error as e:
-        raise PyCurlError(e.args[0], e.args[1])
+        raise TransportError(e.args[0], e.args[1]) from e
 
     body = input.getvalue()
 

--- a/landscape/lib/tests/test_cloud.py
+++ b/landscape/lib/tests/test_cloud.py
@@ -9,7 +9,7 @@ from landscape.lib.cloud import (
     _fetch_ec2_item,
     fetch_ec2_meta_data,
 )
-from landscape.lib.fetch import HTTPCodeError, PyCurlError
+from landscape.lib.fetch import HTTPCodeError, TransportError
 
 
 class CloudTest(
@@ -141,8 +141,8 @@ class CloudTest(
         L{_fetch_ec2_item} returns a deferred C{Failure} containing the error
         message when faced with no EC2 cloud API service.
         """
-        self.log_helper.ignore_errors(PyCurlError)
-        self.add_query_result("other-id", PyCurlError(60, "pycurl error"))
+        self.log_helper.ignore_errors(TransportError)
+        self.add_query_result("other-id", TransportError(60, "pycurl error"))
         accumulate = []
         deferred = _fetch_ec2_item(
             "other-id",
@@ -157,8 +157,8 @@ class CloudTest(
         L{_fetch_ec2_meta_data} sets C{follow} to C{False} to avoid following
         HTTP redirects.
         """
-        self.log_helper.ignore_errors(PyCurlError)
-        self.add_query_result("other-id", PyCurlError(60, "pycurl error"))
+        self.log_helper.ignore_errors(TransportError)
+        self.add_query_result("other-id", TransportError(60, "pycurl error"))
         accumulate = []
         deferred = _fetch_ec2_item(
             "other-id",

--- a/landscape/lib/tests/test_fetch.py
+++ b/landscape/lib/tests/test_fetch.py
@@ -1,5 +1,11 @@
+import gzip
+import io
 import os
+import ssl
 import unittest
+import urllib.error
+import urllib.request
+import zlib
 from threading import local
 from unittest import mock
 
@@ -9,7 +15,8 @@ from twisted.internet.defer import FirstError
 from landscape.lib import testing
 from landscape.lib.fetch import (
     HTTPCodeError,
-    PyCurlError,
+    TransportError,
+    _NoRedirectHandler,
     fetch,
     fetch_async,
     fetch_many_async,
@@ -289,13 +296,10 @@ class FetchTest(
 
     def test_pycurl_error(self):
         curl = CurlStub(error=pycurl.error(60, "pycurl error"))
-        try:
+        with self.assertRaises(TransportError) as cm:
             fetch("http://example.com", curl=curl)
-        except PyCurlError as error:
-            self.assertEqual(error.error_code, 60)
-            self.assertEqual(error.message, "pycurl error")
-        else:
-            self.fail("PyCurlError not raised")
+        self.assertEqual(cm.exception.error_code, 60)
+        self.assertEqual(cm.exception.message, "pycurl error")
 
     def test_pycurl_insecure(self):
         curl = CurlStub(b"result")
@@ -324,14 +328,14 @@ class FetchTest(
 
     def test_pycurl_error_str(self):
         self.assertEqual(
-            str(PyCurlError(60, "pycurl error")),
+            str(TransportError(60, "pycurl error")),
             "Error 60: pycurl error",
         )
 
     def test_pycurl_error_repr(self):
         self.assertEqual(
-            repr(PyCurlError(60, "pycurl error")),
-            "<PyCurlError args=(60, 'pycurl error')>",
+            repr(TransportError(60, "pycurl error")),
+            "<TransportError args=(60, 'pycurl error')>",
         )
 
     def test_pycurl_follow_true(self):
@@ -594,3 +598,384 @@ class FetchTest(
 
         result.addErrback(check_error)
         return result
+
+    def _urllib_opener(
+        self,
+        mock_build_opener,
+        body=b"result",
+        code=200,
+        headers=None,
+    ):
+        """Configure C{mock_build_opener} with an opener returning a response
+        with the given C{body}, HTTP C{code} and C{headers}, and return the
+        opener mock for further assertions.
+        """
+        response = mock.MagicMock()
+        response.read.side_effect = [body, b""]
+        response.getcode.return_value = code
+        response.headers = {} if headers is None else headers
+        response.__enter__.return_value = response
+
+        opener = mock.MagicMock()
+        opener.open.return_value = response
+        mock_build_opener.return_value = opener
+        return opener
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_basic(self, mock_build_opener):
+        """The C{urllib} backend performs a GET request and returns the body."""
+        opener = self._urllib_opener(mock_build_opener)
+
+        result = fetch("http://example.com", http_client="urllib")
+        self.assertEqual(result, b"result")
+
+        opener.open.assert_called_once()
+        req = opener.open.call_args[0][0]
+        self.assertEqual(req.full_url, "http://example.com")
+        self.assertEqual(req.get_method(), "GET")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_post(self, mock_build_opener):
+        """With C{post=True} the C{urllib} backend issues a POST request."""
+        opener = self._urllib_opener(mock_build_opener)
+
+        result = fetch("http://example.com", post=True, http_client="urllib")
+        self.assertEqual(result, b"result")
+
+        req = opener.open.call_args[0][0]
+        self.assertEqual(req.get_method(), "POST")
+        self.assertEqual(req.data, b"")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_post_data(self, mock_build_opener):
+        """POST C{data} is encoded and sent as the request body."""
+        opener = self._urllib_opener(mock_build_opener)
+
+        result = fetch(
+            "http://example.com",
+            post=True,
+            data="post-data",
+            http_client="urllib",
+        )
+        self.assertEqual(result, b"result")
+
+        req = opener.open.call_args[0][0]
+        self.assertEqual(req.get_method(), "POST")
+        self.assertEqual(req.data, b"post-data")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_headers(self, mock_build_opener):
+        """If provided, headers are set on the request."""
+        opener = self._urllib_opener(mock_build_opener)
+
+        result = fetch(
+            "http://example.com",
+            headers={"Custom-Header": "value"},
+            http_client="urllib",
+        )
+        self.assertEqual(result, b"result")
+
+        req = opener.open.call_args[0][0]
+        self.assertEqual(req.get_header("Custom-header"), "value")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_user_agent(self, mock_build_opener):
+        """If provided, the user-agent is set in the request."""
+        opener = self._urllib_opener(mock_build_opener)
+
+        result = fetch(
+            "http://example.com",
+            user_agent="my-user-agent",
+            http_client="urllib",
+        )
+        self.assertEqual(result, b"result")
+
+        req = opener.open.call_args[0][0]
+        self.assertEqual(req.get_header("User-agent"), "my-user-agent")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_proxy(self, mock_build_opener):
+        """If provided, the proxy is set for both http and https."""
+        self._urllib_opener(mock_build_opener)
+
+        result = fetch(
+            "http://example.com",
+            proxy="http://127.0.0.1:8080",
+            http_client="urllib",
+        )
+        self.assertEqual(result, b"result")
+
+        handlers = mock_build_opener.call_args[0]
+        proxy_handlers = [
+            h for h in handlers if isinstance(h, urllib.request.ProxyHandler)
+        ]
+        self.assertEqual(len(proxy_handlers), 1)
+        self.assertEqual(
+            proxy_handlers[0].proxies,
+            {"http": "http://127.0.0.1:8080", "https": "http://127.0.0.1:8080"},
+        )
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_follow_false(self, mock_build_opener):
+        """With C{follow=False} a no-redirect handler is installed."""
+        self._urllib_opener(mock_build_opener)
+
+        result = fetch("http://example.com", follow=False, http_client="urllib")
+        self.assertEqual(result, b"result")
+
+        handlers = mock_build_opener.call_args[0]
+        redirect_handlers = [
+            h for h in handlers if isinstance(h, urllib.request.HTTPRedirectHandler)
+        ]
+        self.assertEqual(len(redirect_handlers), 1)
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_non_200(self, mock_build_opener):
+        """A non-200 response raises L{HTTPCodeError} with code and body."""
+        self._urllib_opener(mock_build_opener, body=b"error body", code=404)
+
+        with self.assertRaises(HTTPCodeError) as cm:
+            fetch("http://example.com", http_client="urllib")
+        self.assertEqual(cm.exception.http_code, 404)
+        self.assertEqual(cm.exception.body, b"error body")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_ssl_verification_error(self, mock_build_opener):
+        """An SSL certificate verification failure maps to error code 60."""
+        opener = mock.MagicMock()
+        reason = ssl.SSLCertVerificationError(1, "self-signed certificate")
+        opener.open.side_effect = urllib.error.URLError(reason)
+        mock_build_opener.return_value = opener
+
+        with self.assertRaises(TransportError) as cm:
+            fetch("https://example.com", http_client="urllib")
+        self.assertEqual(cm.exception.error_code, 60)
+        self.assertIn("self-signed certificate", cm.exception.message)
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_ssl_error(self, mock_build_opener):
+        """A generic SSL error maps to error code 35."""
+        opener = mock.MagicMock()
+        reason = ssl.SSLError("some ssl error")
+        opener.open.side_effect = urllib.error.URLError(reason)
+        mock_build_opener.return_value = opener
+
+        with self.assertRaises(TransportError) as cm:
+            fetch("https://example.com", http_client="urllib")
+        self.assertEqual(cm.exception.error_code, 35)
+        self.assertIn("some ssl error", cm.exception.message)
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_other_error(self, mock_build_opener):
+        """A non-SSL connection error maps to error code 7."""
+        opener = mock.MagicMock()
+        opener.open.side_effect = urllib.error.URLError("connection refused")
+        mock_build_opener.return_value = opener
+
+        with self.assertRaises(TransportError) as cm:
+            fetch("http://example.com", http_client="urllib")
+        self.assertEqual(cm.exception.error_code, 7)
+        self.assertIn("connection refused", cm.exception.message)
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_gzip(self, mock_build_opener):
+        """A gzip-encoded response body is transparently decompressed."""
+        self._urllib_opener(
+            mock_build_opener,
+            body=gzip.compress(b"gzip-decoded"),
+            headers={"Content-Encoding": "gzip"},
+        )
+
+        result = fetch("http://example.com", http_client="urllib")
+        self.assertEqual(result, b"gzip-decoded")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_deflate(self, mock_build_opener):
+        """A deflate-encoded response body is transparently decompressed."""
+        self._urllib_opener(
+            mock_build_opener,
+            body=zlib.compress(b"deflate-decoded"),
+            headers={"Content-Encoding": "deflate"},
+        )
+
+        result = fetch("http://example.com", http_client="urllib")
+        self.assertEqual(result, b"deflate-decoded")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_deflate_raw(self, mock_build_opener):
+        """A raw DEFLATE (RFC 1951) response body is also decompressed."""
+        compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+        raw = compressor.compress(b"deflate-decoded") + compressor.flush()
+        self._urllib_opener(
+            mock_build_opener,
+            body=raw,
+            headers={"Content-Encoding": "deflate"},
+        )
+
+        result = fetch("http://example.com", http_client="urllib")
+        self.assertEqual(result, b"deflate-decoded")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_bytes_url(self, mock_build_opener):
+        """A C{bytes} URL is decoded before the request is built."""
+        opener = self._urllib_opener(mock_build_opener)
+
+        result = fetch(b"http://example.com", http_client="urllib")
+        self.assertEqual(result, b"result")
+
+        req = opener.open.call_args[0][0]
+        self.assertEqual(req.full_url, "http://example.com")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_bytes_user_agent(self, mock_build_opener):
+        """A C{bytes} user-agent is decoded before being set as a header."""
+        opener = self._urllib_opener(mock_build_opener)
+
+        result = fetch(
+            "http://example.com",
+            user_agent=b"my-user-agent",
+            http_client="urllib",
+        )
+        self.assertEqual(result, b"result")
+
+        req = opener.open.call_args[0][0]
+        self.assertEqual(req.get_header("User-agent"), "my-user-agent")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_bytes_proxy(self, mock_build_opener):
+        """A C{bytes} proxy is decoded before the proxy handler is built."""
+        self._urllib_opener(mock_build_opener)
+
+        result = fetch(
+            "http://example.com",
+            proxy=b"http://127.0.0.1:8080",
+            http_client="urllib",
+        )
+        self.assertEqual(result, b"result")
+
+        handlers = mock_build_opener.call_args[0]
+        proxy_handlers = [
+            h for h in handlers if isinstance(h, urllib.request.ProxyHandler)
+        ]
+        self.assertEqual(len(proxy_handlers), 1)
+        self.assertEqual(
+            proxy_handlers[0].proxies,
+            {"http": "http://127.0.0.1:8080", "https": "http://127.0.0.1:8080"},
+        )
+
+    @mock.patch("landscape.lib.fetch.ssl.create_default_context")
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_insecure(self, mock_build_opener, mock_create_ctx):
+        """With C{insecure=True} over HTTPS certificate checks are disabled."""
+        self._urllib_opener(mock_build_opener)
+        ctx = mock_create_ctx.return_value
+
+        result = fetch(
+            "https://example.com",
+            insecure=True,
+            http_client="urllib",
+        )
+        self.assertEqual(result, b"result")
+        self.assertFalse(ctx.check_hostname)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_NONE)
+
+    @mock.patch("landscape.lib.fetch.ssl.create_default_context")
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_cainfo(self, mock_build_opener, mock_create_ctx):
+        """Over HTTPS a readable cainfo file is loaded into the SSL context."""
+        self._urllib_opener(mock_build_opener)
+        ctx = mock_create_ctx.return_value
+        cainfo = self.makeFile("cert-data")
+
+        result = fetch(
+            "https://example.com",
+            cainfo=cainfo,
+            http_client="urllib",
+        )
+        self.assertEqual(result, b"result")
+        ctx.load_verify_locations.assert_called_once_with(cafile=cainfo)
+
+    @mock.patch("landscape.lib.fetch.warning")
+    @mock.patch("landscape.lib.fetch.ssl.create_default_context")
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_cainfo_not_accessible(
+        self,
+        mock_build_opener,
+        mock_create_ctx,
+        mock_warning,
+    ):
+        """Over HTTPS an unreadable cainfo path logs a warning and is skipped."""
+        self._urllib_opener(mock_build_opener)
+        ctx = mock_create_ctx.return_value
+
+        result = fetch(
+            "https://example.com",
+            cainfo="/nonexistent/path/cert.pem",
+            http_client="urllib",
+        )
+        self.assertEqual(result, b"result")
+        mock_warning.assert_called_once()
+        ctx.load_verify_locations.assert_not_called()
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_http_error(self, mock_build_opener):
+        """An C{HTTPError} from the opener is raised as L{HTTPCodeError}."""
+        opener = mock.MagicMock()
+        opener.open.side_effect = urllib.error.HTTPError(
+            "http://example.com",
+            500,
+            "Server Error",
+            {},
+            io.BytesIO(b"error body"),
+        )
+        mock_build_opener.return_value = opener
+
+        with self.assertRaises(HTTPCodeError) as cm:
+            fetch("http://example.com", http_client="urllib")
+        self.assertEqual(cm.exception.http_code, 500)
+        self.assertEqual(cm.exception.body, b"error body")
+
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_unexpected_error(self, mock_build_opener):
+        """An unexpected error is wrapped in L{TransportError} with code 0."""
+        opener = mock.MagicMock()
+        opener.open.side_effect = ValueError("boom")
+        mock_build_opener.return_value = opener
+
+        with self.assertRaises(TransportError) as cm:
+            fetch("http://example.com", http_client="urllib")
+        self.assertEqual(cm.exception.error_code, 0)
+        self.assertIn("boom", cm.exception.message)
+
+    @mock.patch("landscape.lib.fetch.time.monotonic")
+    @mock.patch("landscape.lib.fetch.urllib.request.build_opener")
+    def test_urllib_low_speed_abort(self, mock_build_opener, mock_monotonic):
+        """A transfer slower than one byte/s past total_timeout is aborted."""
+        # start=0, then the elapsed check reads a time past the default
+        # total_timeout (600s) while only a single byte has been received
+        mock_monotonic.side_effect = [0, 601, 602]
+        response = mock.MagicMock()
+        response.read.side_effect = [b"x", b"y", b""]
+        response.getcode.return_value = 200
+        response.headers = {}
+        response.__enter__.return_value = response
+        opener = mock.MagicMock()
+        opener.open.return_value = response
+        mock_build_opener.return_value = opener
+
+        with self.assertRaises(TransportError) as cm:
+            fetch("http://example.com", http_client="urllib")
+        self.assertEqual(cm.exception.error_code, 28)
+
+    def test_no_redirect_handler_returns_none(self):
+        """C{_NoRedirectHandler} suppresses redirects by returning C{None}."""
+        handler = _NoRedirectHandler()
+        result = handler.redirect_request(
+            None,
+            None,
+            302,
+            "Found",
+            {},
+            "http://example.com/other",
+        )
+        self.assertIsNone(result)


### PR DESCRIPTION
## Summary
Adds a `urllib`-based HTTP backend to `landscape.lib.fetch` that can be used instead of pycurl, selectable via a new `--http-client` option. pycurl remains the default, the urllib backend is purely opt-in.

Some self-hosted Landscape servers present TLS certificate chains that exceed the certificate-depth limit hard-coded in libcurl/GnuTLS. When that happens, registration and message exchange fail with a pycurl error 35 (surfaced as a GnuTLS `-101` / constraint error) and there is currently no client-side workaround. Python's `urllib`/`ssl` does not impose the same limit, so offering it as an alternative backend unblocks these deployments.

## Changes
- `fetch()` has an addded `http_client` parameter (`"pycurl"` | `"urllib"`). When set to `"urllib"`, requests are served by a new fetch implementation
- `--http-client` option registered in the broker config (`default="pycurl"`, `choices=["pycurl", "urllib"]`) and threaded through the call chain: broker service -> configuration/registration -> exchange -> transport.
- on the cert-depth failure (error 35 with `-101`/constraint, the issue in the related LP bug), registration now raises a clear `RegistrationException` recommending the user retry with the `--http-client urllib` option
- the urllib implementation maps `ssl`/`urllib` failures onto the same `HTTPCodeError` / transport-error types the existing pycurl backend already raised, so callers handle both backends identically
- the transport exception `PyCurlError` was renamed to the backend-neutral `TransportError`, since it is raised by both backends. A backward-compatible alias `PyCurlError = TransportError` is included

## Backward compatibility:
- The default behavior is unchanged (pycurl remains the default backend)
- `PyCurlError` is still importable and still catches the same errors via the alias


## Testing
- New `_fetch_urllib` coverage in test_fetch.py (success, headers/user-agent, redirects, gzip/deflate, HTTP error codes, and SSL/connection error mapping).
- Registration tests cover the new cert-depth hint and the `--http-client urllib` message.


## Launchpad Bug:

https://bugs.launchpad.net/landscape-client/+bug/2159858
