### PR TITLE
fix: snap release workflow

### DIFF
--- a/.github/workflows/snap-builds.yml
+++ b/.github/workflows/snap-builds.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/update-release-branches.yml
+++ b/.github/workflows/update-release-branches.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-release-branches:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:
@@ -19,10 +21,11 @@ jobs:
             base: core22
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           submodules: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The [org-level default workflow privileges were updated](https://discourse.canonical.com/t/upcoming-change-to-github-actions-settings/7286) from "read and write" to "read". This PR fixes the "Update release branches" workflow with the right permissions to write to the release branches.