### PR TITLE
fix: snap builds failing on Launchpad due to missing pip

### DIFF
--- a/README
+++ b/README
@@ -125,6 +125,10 @@ By default this targets `core26`. To target a different base, pass `SNAP_BASE`:
 make snap-yaml SNAP_BASE=core24
 ```
 
+When making significant changes to `snap/snapcraft.yaml.j2`, validate against
+Launchpad using `snapcraft remote-build --build-for=<arch> -v` in addition to the [GitHub Actions workflow](.github/workflows/snap-builds.yml).
+The two build environments differ and a build can pass on GitHub while failing on Launchpad.
+
 To simply build the snap with the minimum of debug information displayed:
 
 ```shell
@@ -248,3 +252,5 @@ The landscape-client snap is automatically built from the most recent commit on 
 | 22        | `22/edge`    | [core-22](https://launchpad.net/~landscape/landscape-client/+snap/core-22) |
 
 Other channels (`<base>/beta`, `<base>/candidate`, `<base>/stable`) are promoted and released manually.
+
+For the team maintaining this snap, see the [internal support documentation](https://documentation.ubuntu.com/telemetry-internal/en/latest/how-to/support/landscape-client/) for release procedures and common support tasks.

--- a/snap/snapcraft.yaml.j2
+++ b/snap/snapcraft.yaml.j2
@@ -1,4 +1,4 @@
-{# this is a template, generate the actual snapcraft.yaml with `make snap-yaml` #}
+{# This is a template, generate the actual snapcraft.yaml with `make snap-yaml`. #}
 {%- set python_versions = {"core22": "3.10", "core24": "3.12", "core26": "3.14"} -%}
 {%- set python_version = python_versions[base] -%}
 {%- set supported_archs = ["amd64", "arm64", "armhf", "ppc64el", "s390x", "riscv64"] -%}
@@ -123,6 +123,7 @@ parts:
       - python3-dbus
       - python3-dev
       - python3-netifaces
+      - python3-pip
       - python3-pycurl
       - python3-setuptools
       - python3-twisted


### PR DESCRIPTION
The landscape-client snap builds are failing on Launchpad for all core bases after the snap was updated to support `core26`. The builds passed on GitHub Actions because its hosted runners have `pip` available, while the Launchpad build containers do not. This PR fixes that by explicitly adding `python3-pip` to `build-packages` , ensuring `pip` is available in the build environment regardless of where the build runs.

----

[Here's](https://launchpadlibrarian.net/869837993/buildlog_snap_ubuntu_jammy_amd64_snapcraft-landscape-client-df725094ff8fdf7db7f434c55e1f4b8d_BUILDING.txt.gz) a reproduction of the issue:

```
Building landscape-client
:: + pip install --target=/build/snapcraft-landscape-client-df725094ff8fdf7db7f434c55e1f4b8d/parts/landscape-client/install/lib/python3.10/site-packages .
:: /tmp/tmp2nb10vd7/scriptlet.sh: line 5: pip: command not found
'override-build' in part 'landscape-client' failed with code 127.

:: + pip install --target=/build/snapcraft-landscape-client-df725094ff8fdf7db7f434c55e1f4b8d/parts/landscape-client/install/lib/python3.10/site-packages .
:: /tmp/tmp2nb10vd7/scriptlet.sh: line 5: pip: command not found
Review the scriptlet and make sure it's correct.
Full execution log: '/root/.local/state/snapcraft/log/snapcraft-20260720-084222.174587.log'
Build failed
```

I've confirmed the build works after the fix with `snapcraft remote-build --build-for=amd64 -v`:

- [core22 build log](https://github.com/user-attachments/files/30188976/snapcraft-landscape-client-32b05f1e1dc2d42c3fc915a94bc78e9d_amd64_2026-07-20T16.07.12.txt)
- [core24 build log](https://github.com/user-attachments/files/30191374/snapcraft-landscape-client-8cb8e040716754bec81645eccdbdea75_amd64_2026-07-20T16.56.13.txt)
- [core26 build log](https://github.com/user-attachments/files/30189818/snapcraft-landscape-client-7b2a62220526bf9f58fffd89d834351d_amd64_2026-07-20T16.29.41.txt)

And the snap installs and works as expected:

<img width="1918" height="934" alt="Untitled" src="https://github.com/user-attachments/assets/53e0d5c1-e8e2-47e0-9397-eea9ad8a0c30" />
