### PR TITLE
refactor: cap error count for exponential backoff

### DIFF
--- a/landscape/lib/backoff.py
+++ b/landscape/lib/backoff.py
@@ -43,8 +43,7 @@ class ExponentialBackoff:
         Increases the error count, capped at the limit needed
         to reach the maximum delay.
         """
-        if self._error_count < self._max_effective_error_count:
-            self._error_count += 1
+        self._error_count = min(self._error_count + 1, self._max_effective_error_count)
 
     def get_delay(self) -> int:
         """

--- a/landscape/lib/backoff.py
+++ b/landscape/lib/backoff.py
@@ -1,3 +1,17 @@
+"""
+Exponential Backoff Utility.
+
+This module provides an implementation of an exponential backoff algorithm.
+
+It features:
+- Exponentially increasing delays based on consecutive error counts.
+- A configurable maximum delay ceiling to prevent unbounded waits.
+- Gradual recovery by stepping down the error count on success.
+- Randomized jitter to prevent "thundering herd" scenarios when multiple
+  clients are retrying simultaneously.
+"""
+
+import math
 import random
 
 
@@ -7,23 +21,30 @@ class ExponentialBackoff:
     exponentially.
     """
 
-    def __init__(self, start_delay, max_delay):
+    def __init__(self, start_delay: int, max_delay: int):
         self._error_count = 0  # A tally of server errors
 
         self._start_delay = start_delay
         self._max_delay = max_delay
+        self._max_effective_error_count: int = 1
 
-    def decrease(self):
+        # Calculate he smallest error count that meets or exceeds max_delay
+        if (self._start_delay > 0) and (self._max_delay > self._start_delay):
+            self._max_effective_error_count = math.ceil(
+                math.log2(self._max_delay / self._start_delay) + 1
+            )
+
+    def decrease(self) -> None:
         """Decreases error count with zero being the lowest"""
         self._error_count -= 1
         self._error_count = max(self._error_count, 0)
 
-    def increase(self):
+    def increase(self) -> None:
         """Increases error count but not higher than gives the max delay"""
-        if self.get_delay() < self._max_delay:
+        if self._error_count < self._max_effective_error_count:
             self._error_count += 1
 
-    def get_delay(self):
+    def get_delay(self) -> int:
         """
         Calculates the delay using formula that gives this chart. In this
         specific example start is 5 seconds and max is 60 seconds
@@ -36,12 +57,12 @@ class ExponentialBackoff:
                 5      60 (max)
         """
         if self._error_count:
-            delay = (2 ** (self._error_count - 1)) * self._start_delay
+            delay = self._start_delay << (self._error_count - 1)
         else:
             delay = 0
         return min(int(delay), self._max_delay)
 
-    def get_random_delay(self, stagger_fraction=0.25):
+    def get_random_delay(self, stagger_fraction: float = 0.25) -> int:
         """
         Adds randomness to the specified stagger of the delay. For example
         for a delay of 12 and 25% stagger, it works out to 9 + rand(0,3)

--- a/landscape/lib/backoff.py
+++ b/landscape/lib/backoff.py
@@ -28,7 +28,7 @@ class ExponentialBackoff:
         self._max_delay = max_delay
         self._max_effective_error_count: int = 1
 
-        # Calculate he smallest error count that meets or exceeds max_delay
+        # Calculate the smallest error count that meets or exceeds max_delay
         if (self._start_delay > 0) and (self._max_delay > self._start_delay):
             self._max_effective_error_count = math.ceil(
                 math.log2(self._max_delay / self._start_delay) + 1
@@ -40,7 +40,10 @@ class ExponentialBackoff:
         self._error_count = max(self._error_count, 0)
 
     def increase(self) -> None:
-        """Increases error count but not higher than gives the max delay"""
+        """
+        Increases the error count, capped at the limit needed
+        to reach the maximum delay.
+        """
         if self._error_count < self._max_effective_error_count:
             self._error_count += 1
 

--- a/landscape/lib/backoff.py
+++ b/landscape/lib/backoff.py
@@ -29,15 +29,14 @@ class ExponentialBackoff:
         self._max_effective_error_count: int = 1
 
         # Calculate the smallest error count that meets or exceeds max_delay
-        if (self._start_delay > 0) and (self._max_delay > self._start_delay):
+        if self._max_delay > self._start_delay > 0:
             self._max_effective_error_count = math.ceil(
                 math.log2(self._max_delay / self._start_delay) + 1
             )
 
     def decrease(self) -> None:
         """Decreases error count with zero being the lowest"""
-        self._error_count -= 1
-        self._error_count = max(self._error_count, 0)
+        self._error_count = max(self._error_count - 1, 0)
 
     def increase(self) -> None:
         """

--- a/landscape/lib/tests/test_backoff.py
+++ b/landscape/lib/tests/test_backoff.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from landscape.client.tests.helpers import LandscapeTest
 from landscape.lib.backoff import ExponentialBackoff
 
@@ -34,3 +36,51 @@ class TestBackoff(LandscapeTest):
             backoff_counter.increase()
         backoff_counter.decrease()
         self.assertTrue(backoff_counter.get_delay() < 5)
+
+    def test_error_count_cap(self):
+        """Test that the internal error count never exceeds the effective max"""
+        backoff_counter = ExponentialBackoff(5, 60)
+
+        # Increase well beyond the effective max
+        for _ in range(15):
+            backoff_counter.increase()
+
+        self.assertEqual(backoff_counter._error_count, 5)
+        self.assertEqual(
+            backoff_counter._error_count, backoff_counter._max_effective_error_count
+        )
+
+    def test_init_edge_cases(self):
+        """Test the max_effective_error_count logic handles edge cases properly"""
+        # start_delay is 0
+        backoff_zero = ExponentialBackoff(0, 60)
+        self.assertEqual(backoff_zero._max_effective_error_count, 1)
+
+        # start_delay is greater than max_delay
+        backoff_inverted = ExponentialBackoff(20, 5)
+        self.assertEqual(backoff_inverted._max_effective_error_count, 1)
+
+        # start_delay is equal to max_delay
+        backoff_equal = ExponentialBackoff(5, 5)
+        self.assertEqual(backoff_equal._max_effective_error_count, 1)
+
+    @mock.patch("landscape.lib.backoff.random.random")
+    def test_get_random_delay(self, mock_random):
+        """Test the random delay calculation boundaries"""
+        backoff_counter = ExponentialBackoff(4, 10)
+        backoff_counter.increase()  # Delay is now 4
+
+        # Test the lower bound (random() returns 0.0)
+        mock_random.return_value = 0.0
+        # For a delay of 4 with 25% stagger, non-random part is 3.
+        # 3 + (1 * 0.0) = 3
+        self.assertEqual(backoff_counter.get_random_delay(stagger_fraction=0.25), 3)
+
+        # Test the upper bound (random() returns 0.99)
+        mock_random.return_value = 0.9999
+        # 3 + (1 * ~1.0) = 3 (truncated to int)
+        self.assertEqual(backoff_counter.get_random_delay(stagger_fraction=0.25), 3)
+
+        # At exactly 1.0 it would be 4
+        mock_random.return_value = 1.0
+        self.assertEqual(backoff_counter.get_random_delay(stagger_fraction=0.25), 4)

--- a/landscape/lib/tests/test_backoff.py
+++ b/landscape/lib/tests/test_backoff.py
@@ -67,20 +67,21 @@ class TestBackoff(LandscapeTest):
     @mock.patch("landscape.lib.backoff.random.random")
     def test_get_random_delay(self, mock_random):
         """Test the random delay calculation boundaries"""
-        backoff_counter = ExponentialBackoff(4, 10)
-        backoff_counter.increase()  # Delay is now 4
+        backoff_counter = ExponentialBackoff(100, 1000)
+        backoff_counter.increase()  # Delay is now 100
 
         # Test the lower bound (random() returns 0.0)
         mock_random.return_value = 0.0
-        # For a delay of 4 with 25% stagger, non-random part is 3.
-        # 3 + (1 * 0.0) = 3
-        self.assertEqual(backoff_counter.get_random_delay(stagger_fraction=0.25), 3)
+        # For a delay of 100 with 25% stagger, non-random part is 75.
+        # 75 + (25 * 0.0) = 75
+        self.assertEqual(backoff_counter.get_random_delay(stagger_fraction=0.25), 75)
 
-        # Test the upper bound (random() returns 0.99)
+        # Test the upper bound (random() approaches 1.0 but never reaches it)
         mock_random.return_value = 0.9999
-        # 3 + (1 * ~1.0) = 3 (truncated to int)
-        self.assertEqual(backoff_counter.get_random_delay(stagger_fraction=0.25), 3)
+        # 75 + (25 * 0.9999) = 99.9975 (truncated to int)
+        self.assertEqual(backoff_counter.get_random_delay(stagger_fraction=0.25), 99)
 
-        # At exactly 1.0 it would be 4
-        mock_random.return_value = 1.0
-        self.assertEqual(backoff_counter.get_random_delay(stagger_fraction=0.25), 4)
+        # Test the median to ensure standard math is applied correctly
+        mock_random.return_value = 0.5
+        # 75 + (25 * 0.5) = 87.5 (truncated to int)
+        self.assertEqual(backoff_counter.get_random_delay(stagger_fraction=0.25), 87)

--- a/landscape/lib/tests/test_backoff.py
+++ b/landscape/lib/tests/test_backoff.py
@@ -45,7 +45,6 @@ class TestBackoff(LandscapeTest):
         for _ in range(15):
             backoff_counter.increase()
 
-        self.assertEqual(backoff_counter._error_count, 5)
         self.assertEqual(
             backoff_counter._error_count, backoff_counter._max_effective_error_count
         )


### PR DESCRIPTION
Previously, the error count would grow without bound, even though the max delay effectively capped the delay. Message exchange has a hard coded max delay of 7200 seconds (2 hours). That means if the client's message exchange failed 10 times in a row, it could be more than a day before message exchange goes back to normal.

With these changes, the error count is capped to a level based on the configured start and max delay values.