### PR TITLE
fix: broker stale socket recovery

### DIFF
--- a/landscape/client/amp.py
+++ b/landscape/client/amp.py
@@ -11,8 +11,12 @@ let the various services connect to each other in an easy and idiomatic way,
 and have them respond to standard requests like "ping" or "exit".
 """
 
+import errno
 import logging
 import os
+import socket as socket_module
+
+from twisted.internet import error as tw_error
 
 from landscape.lib.amp import (
     MethodCallClientFactory,
@@ -43,10 +47,35 @@ class ComponentPublisher:
         self.methods = get_remote_methods(type(component)).keys()
 
     def start(self):
-        """Start accepting connections."""
+        """Start accepting connections.
+
+        If a previous instance of this component died without cleaning up
+        (e.g. it was SIGKILLed by the watchdog), its socket file may be left
+        behind with no live listener on it, which makes the bind fail with
+        C{EADDRINUSE}. In that case we remove the stale socket and retry once,
+        rather than crash and let the watchdog give up restarting us. A socket
+        that still has a live listener is left untouched and the error is
+        re-raised, so a genuine duplicate process is still refused.
+        """
         factory = MethodCallServerFactory(self._component, self.methods)
         socket_path = _get_socket_path(self._component, self._config)
-        self._port = self._reactor.listen_unix(socket_path, factory)
+        self._port = self._listen_recovering_stale(socket_path, factory)
+
+    def _listen_recovering_stale(self, socket_path, factory):
+        try:
+            return self._reactor.listen_unix(socket_path, factory)
+        except tw_error.CannotListenError as error:
+            if not (
+                _is_addr_in_use(error) and _socket_has_no_live_listener(socket_path)
+            ):
+                raise
+            logging.warning(
+                "Removing stale socket %s left behind by a dead process, "
+                "retrying listen.",
+                socket_path,
+            )
+            _remove_socket_file(socket_path)
+            return self._reactor.listen_unix(socket_path, factory)
 
     def stop(self):
         """Stop accepting connections."""
@@ -158,3 +187,45 @@ class ComponentConnector:
 
 def _get_socket_path(component, config):
     return os.path.join(config.sockets_path, component.name + ".sock")
+
+
+def _is_addr_in_use(cannot_listen_error):
+    """Return True if C{CannotListenError} was caused by the address being busy.
+
+    The underlying socket error is available as C{socketError}; on Linux a
+    leftover unix socket yields C{EADDRINUSE}, and a leftover lock or
+    restrictive permissions can surface as C{EACCES}.
+    """
+    socket_error = getattr(cannot_listen_error, "socketError", None)
+    return isinstance(socket_error, OSError) and socket_error.errno in (
+        errno.EADDRINUSE,
+        errno.EACCES,
+    )
+
+
+def _socket_has_no_live_listener(path):
+    """Return True if nothing is accepting connections on the unix socket.
+
+    A stale socket file left by a dead process refuses connections
+    (C{ECONNREFUSED}) or is simply absent (C{ENOENT}); a live process accepts
+    the connection. We only treat the former as safe to remove, so we never
+    delete a socket a running component is genuinely serving.
+    """
+    if not os.path.exists(path):
+        return True
+    probe = socket_module.socket(socket_module.AF_UNIX, socket_module.SOCK_STREAM)
+    try:
+        probe.connect(path)
+    except OSError:
+        return True
+    finally:
+        probe.close()
+    return False
+
+
+def _remove_socket_file(path):
+    """Remove a stale socket path, tolerating a non-socket inode left behind."""
+    if os.path.isdir(path) and not os.path.islink(path):
+        os.rmdir(path)
+    else:
+        os.unlink(path)

--- a/landscape/client/tests/test_amp.py
+++ b/landscape/client/tests/test_amp.py
@@ -1,5 +1,6 @@
 import errno
 import os
+import socket as socket_module
 from unittest import mock
 
 from twisted.internet.error import CannotListenError, ConnectError
@@ -64,6 +65,47 @@ class ComponentPublisherTest(LandscapeTest):
         result = self.remote.non_remote()
         failure = self.failureResultOf(result)
         self.assertTrue(failure.check(MethodCallError))
+
+
+class ComponentPublisherStaleSocketTest(LandscapeTest):
+    """The publisher recovers from a stale socket left by a dead process."""
+
+    def setUp(self):
+        super().setUp()
+        self.config = Configuration()
+        self.config.data_path = self.makeDir()
+        self.makeDir(path=self.config.sockets_path)
+        self.sock_path = os.path.join(self.config.sockets_path, "test.sock")
+
+    def test_recovers_from_stale_socket(self):
+        """A leftover socket with no live listener is removed and re-bound."""
+        # Simulate a SIGKILLed component: a bound socket file with nobody
+        # listening on it (close immediately, leaving the file behind).
+        stale = socket_module.socket(socket_module.AF_UNIX, socket_module.SOCK_STREAM)
+        stale.bind(self.sock_path)
+        stale.close()
+        self.assertTrue(os.path.exists(self.sock_path))
+
+        # Test the actual Unix reactor implementation. Fakes won't do.
+        reactor = LandscapeReactor()
+        publisher = ComponentPublisher(MockComponent(), reactor, self.config)
+        publisher.start()  # must not raise CannotListenError
+        self.assertTrue(os.path.exists(self.sock_path))
+        publisher.stop()
+        reactor._cleanup()
+
+    def test_refuses_socket_with_live_listener(self):
+        """A socket still served by a live process is left untouched."""
+        live = socket_module.socket(socket_module.AF_UNIX, socket_module.SOCK_STREAM)
+        live.bind(self.sock_path)
+        live.listen(1)
+        self.addCleanup(live.close)
+
+        reactor = LandscapeReactor()
+        publisher = ComponentPublisher(MockComponent(), reactor, self.config)
+        with self.assertRaises(CannotListenError):
+            publisher.start()
+        reactor._cleanup()
 
 
 class ComponentConnectorTest(LandscapeTest):

--- a/landscape/client/tests/test_amp.py
+++ b/landscape/client/tests/test_amp.py
@@ -6,7 +6,13 @@ from unittest import mock
 from twisted.internet.error import CannotListenError, ConnectError
 from twisted.internet.task import Clock
 
-from landscape.client.amp import ComponentConnector, ComponentPublisher, remote
+from landscape.client.amp import (
+    ComponentConnector,
+    ComponentPublisher,
+    _remove_socket_file,
+    _socket_has_no_live_listener,
+    remote,
+)
 from landscape.client.deployment import Configuration
 from landscape.client.reactor import LandscapeReactor
 from landscape.client.tests.helpers import LandscapeTest, ready_subprocess
@@ -276,3 +282,67 @@ class ComponentConnectorTest(LandscapeTest):
             self.assertEqual(str(call.pid), os.readlink(lock_path))
             mock_kill.assert_called_with(call.pid, 0)
             reactor._cleanup()
+
+
+class SocketHasNoLiveListenerTest(LandscapeTest):
+    def test_missing_path_has_no_listener(self):
+        """A path that does not exist has no live listener."""
+        path = os.path.join(self.makeDir(), "missing.sock")
+        self.assertTrue(_socket_has_no_live_listener(path))
+
+    def test_stale_socket_refusing_connection(self):
+        """
+        A socket file with nothing accepting connections raises OSError on
+        connect and is reported as having no live listener.
+        """
+        path = os.path.join(self.makeDir(), "stale.sock")
+        stale = socket_module.socket(
+            socket_module.AF_UNIX,
+            socket_module.SOCK_STREAM,
+        )
+        stale.bind(path)
+        stale.close()
+        self.assertTrue(os.path.exists(path))
+        self.assertTrue(_socket_has_no_live_listener(path))
+
+    def test_live_listener_is_detected(self):
+        """A socket with a listener accepting connections is reported live."""
+        path = os.path.join(self.makeDir(), "live.sock")
+        live = socket_module.socket(
+            socket_module.AF_UNIX,
+            socket_module.SOCK_STREAM,
+        )
+        live.bind(path)
+        live.listen(1)
+        self.addCleanup(live.close)
+        self.assertFalse(_socket_has_no_live_listener(path))
+
+
+class RemoveSocketFileTest(LandscapeTest):
+    def test_remove_socket_file(self):
+        """A regular socket file is unlinked."""
+        path = os.path.join(self.makeDir(), "test.sock")
+        with open(path, "w"):
+            pass
+        self.assertTrue(os.path.exists(path))
+        _remove_socket_file(path)
+        self.assertFalse(os.path.exists(path))
+
+    def test_remove_directory_left_behind(self):
+        """A directory left in place of a socket is removed with rmdir."""
+        path = os.path.join(self.makeDir(), "stale")
+        os.mkdir(path)
+        self.assertTrue(os.path.isdir(path))
+        self.assertFalse(os.path.islink(path))
+        _remove_socket_file(path)
+        self.assertFalse(os.path.exists(path))
+
+    def test_remove_symlink_to_directory(self):
+        """A symlink pointing at a directory is unlinked rather than rmdir'd."""
+        target = self.makeDir()
+        path = os.path.join(self.makeDir(), "link")
+        os.symlink(target, path)
+        self.assertTrue(os.path.islink(path))
+        _remove_socket_file(path)
+        self.assertFalse(os.path.lexists(path))
+        self.assertTrue(os.path.isdir(target))


### PR DESCRIPTION
When the watchdog SIGKILLs a broker, its unix socket (broker.sock) is left behind with no live listener. The next broker fails to bind it (CannotListenError: Address already in use) and crashes during startup — before logging, so it only shows in the journal. After 5 quick crashes the watchdog gives up and exits 0, so systemd never restarts the client. Device stays online but goes dark on Landscape until snap restart.