### PR TITLE
doc: fix inaccurate note about script users default

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -202,7 +202,9 @@ manager_plugins = ALL
 
 # A comma-separated list of usernames that scripts can run as.
 #
-# By default, all usernames are allowed.
+# By default, scripts can only be run as the "nobody" user. The special value "ALL"
+# means scripts can run as any user. The ScriptExecution manager plugin is required for
+# script execution to work.
 #script_users = ALL
 
 


### PR DESCRIPTION
I was following this file to test script execution briefly for the upgrade (it's the top result for "landscape client.conf"). In my testing I found that you have to explicitly specify `script_users`, meaning the comment here is inaccurate. I verified as much in the code but that could use double checking. Here is my source:

`landscape/client/manager/config.py`
```
    def get_allowed_script_users(self):
        """
        Based on the C{script_users} configuration value, return the users that
        should be allowed to run scripts.

        If the value is "ALL", then
        L{landscape.manager.scriptexecution.ALL_USERS} will be returned.  If
        there is no specified value, then C{nobody} will be allowed.
        """
        if not self.script_users:
            return ["nobody"]
        if self.script_users.strip() == "ALL":
            return ALL_USERS
        return [x.strip() for x in self.script_users.split(",")]
```