### PR TITLE
build: release 26.08 for jammy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+landscape-client (26.08-0landscape0) jammy; urgency=medium
+
+  * refactor: cap error count for exponential backoff
+
+ -- Joey Mucci <joseph.mucci@canonical.com>  Mon, 10 Aug 2026 12:00:24 -0400
+
 landscape-client (26.08~beta.4-0landscape0) jammy; urgency=medium
 
   * fix: set User-Agent for ping requests

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ landscape-client (26.08-0landscape0) jammy; urgency=medium
 
   * refactor: cap error count for exponential backoff
 
- -- Joey Mucci <joseph.mucci@canonical.com>  Mon, 10 Aug 2026 12:00:24 -0400
+ -- Joey Mucci <joseph.mucci@canonical.com>  Wed, 12 Aug 2026 11:10:43 -0400
 
 landscape-client (26.08~beta.4-0landscape0) jammy; urgency=medium
 

--- a/landscape/__init__.py
+++ b/landscape/__init__.py
@@ -1,6 +1,6 @@
-DEBIAN_REVISION = "-0landscape0"
-UPSTREAM_VERSION = "26.08~beta.4"
-PYTHON_VERSION = "26.8b4"
+DEBIAN_REVISION = ""
+UPSTREAM_VERSION = "26.08"
+PYTHON_VERSION = "26.08"
 VERSION = f"{UPSTREAM_VERSION}{DEBIAN_REVISION}"
 
 # The minimum server API version that all Landscape servers are known to speak

--- a/landscape/__init__.py
+++ b/landscape/__init__.py
@@ -1,6 +1,6 @@
 DEBIAN_REVISION = ""
 UPSTREAM_VERSION = "26.08"
-PYTHON_VERSION = "26.08"
+PYTHON_VERSION = "26.8"
 VERSION = f"{UPSTREAM_VERSION}{DEBIAN_REVISION}"
 
 # The minimum server API version that all Landscape servers are known to speak


### PR DESCRIPTION
Jira Ticket: https://warthogs.atlassian.net/browse/LNDENG-4348
Build Workflow: https://github.com/canonical/landscape-client/actions/runs/31417825351

I did some verification for the release artifact artifacr, verifying two launchpad bugs that have been fixed since 26.02. Since I opened this PR. You can see the output in the linked jira ticket. I also connected it to staging and sucessfully ran a script. There has been one commit about changing our example.conf, I do not think I need to create a changelog entry for that but I can if needed.