### PR TITLE
fix: client config file permissions in snap (LP# 2161005)

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -77,6 +77,11 @@ for snapctl_key, landscape_key, mapping_fn in [*legacy_config_entries, *config_e
 
 config.write()
 
+# May contain sensitive values (e.g. registration_key); keep it locked down.
+# config.write() doesn't reset permissions on an existing file, but this is
+# defense-in-depth for cases where the underlying file didn't already exist.
+os.chmod(config.get_config_filename(), 0o600)
+
 # Unset changed keys so that on the next run we know what has changed.
 if changed:
     _snapctl("unset", *changed)

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -56,3 +56,6 @@ fi
 if [ -n "$_registration_key" ]; then
   echo "registration_key = $_registration_key" >> "$CLIENT_CONF"
 fi
+
+# May contain sensitive values (e.g. registration_key); keep it locked down.
+chmod 600 "$CLIENT_CONF"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,5 +1,17 @@
 #!/bin/sh -e
 
+# The "layout: bind-file" entry in snapcraft.yaml makes snapd auto-create
+# $SNAP_COMMON/etc/landscape-client.conf (if it doesn't exist yet) before any
+# hook runs, so that it can be bind-mounted onto /etc/landscape-client.conf.
+# Snapd always creates such placeholder files with mode 0755, which is too
+# permissive for a config file that may contain secrets (e.g. registration
+# key). Lock it down here, since this hook runs first and permissions set on
+# the underlying $SNAP_COMMON file propagate through the bind mount.
+CLIENT_CONF="${SNAP_COMMON}/etc/landscape-client.conf"
+mkdir -p "$(dirname "$CLIENT_CONF")"
+touch "$CLIENT_CONF"
+chmod 600 "$CLIENT_CONF"
+
 if [ "$( snapctl model | awk '/^classic:/ { print $2 }' )" != "true" ]
 then snapctl start --enable "$SNAP_INSTANCE_NAME.landscape-client"
 fi


### PR DESCRIPTION
## Manual testing instructions

1. Install the snap from the store and register with Landscape Server.

    ```bash
    sudo snap install landscape-client
    ```

1. Check the file permissions are 755:

    ```bash
    ls -la /var/snap/landscape-client/common/etc/landscape-client.conf
    ```

1. Register with Landscape Server

    ```bash
    sudo landscape-client.config
    ```

1. Pack the snap from this branch.

    ```bash
    make snap
    ```

1. Install it.

    ```bash
    sudo snap install --dangerous ./landscape-client_26.08_amd64.snap
    ```

1. Check the file permissions are 600.

    ```bash
    ls -la /var/snap/landscape-client/common/etc/landscape-client.conf
    ```

1. Kick off an activity for the client and make sure it works.
