### PR TITLE
fix: restrict client.conf permissions

### DIFF
--- a/debian/landscape-client.postinst
+++ b/debian/landscape-client.postinst
@@ -37,7 +37,8 @@ url = https://landscape.canonical.com/message-system
 ping_url = http://landscape.canonical.com/ping
 data_path = /var/lib/landscape/client
 END
-            chown landscape:landscape "$TEMPFILE"
+            chmod 0640 "$TEMPFILE"
+            chown root:landscape "$TEMPFILE"
             mv "$TEMPFILE" "$CONFIG_FILE"
 
             # Get configuration values from debconf
@@ -81,8 +82,8 @@ END
             fi
         else
             # Fix non-private permissions
-            chmod 0600 $CONFIG_FILE
-            chown landscape:landscape $CONFIG_FILE
+            chmod 0640 "$CONFIG_FILE"
+            chown root:landscape "$CONFIG_FILE"
         fi
 
         # Remove statoverride for smart-update, if there's one

--- a/debian/landscape-common.postinst
+++ b/debian/landscape-common.postinst
@@ -76,7 +76,7 @@ case "$1" in
         if [ -d /var/lib/landscape/client ]; then
             find /var/lib/landscape/client/ -wholename /var/lib/landscape/client/custom-graph-scripts -prune -or -exec chown landscape {} \; > /dev/null 2>&1
         fi
-        chown -Rf landscape:root /etc/landscape/client.conf || true
+        chown -Rf root:landscape /etc/landscape/client.conf || true
 
         #########################################
         # from landscape-sysinfo


### PR DESCRIPTION
https://warthogs.atlassian.net/browse/LNDENG-4928

This PR modifies the postinstall files to grant `640 root:landscape` permissions to `/etc/landscape/client.conf`

## Build
https://github.com/canonical/landscape-client/actions/runs/32982758661

Also published [here](https://launchpad.net/~joey-mucci/+archive/ubuntu/client?field.series_filter=jammy) on 8/26

## Manual Testing
I used this [script](https://github.com/jmucc/my-devscripts/blob/main/client-container.py) and connected to my dev server at landscape-server-noble

### Fresh Install
```
python3 client-container.py --ip 10.38.167.231 --hostname landscape-server-noble --account-name onward --series jammy --ppas joey-mucci/client --client-name fresh-install
```

```
$ lxc exec fresh-install -- ls -lah /etc/landscape/client.conf
-rw-r----- 1 root landscape 282 Aug 31 21:00 /etc/landscape/client.conf
```

### Upgrade Path
```
python3 client-container.py --ip 10.38.167.231 --hostname landscape-server-noble --account-name onward --series jammy --ppas landscape/self-hosted-beta,joey-mucci/client --client-name upgrade
```

```
$ lxc exec upgrade -- ls -lah /etc/landscape/client.conf
-rw------- 1 landscape landscape 276 Aug 31 21:03 /etc/landscape/client.conf

$ lxc exec upgrade -- sudo apt install -y landscape-common=26.08-0landscape0 landscape-client=26.08-0landscape0

$ lxc exec upgrade -- ls -lah /etc/landscape/client.conf
-rw-r----- 1 root landscape 276 Aug 31 21:04 /etc/landscape/client.conf
```


### https://github.com/canonical/landscape-client/security/advisories/GHSA-pmc5-88qj-qqrq
Script trying to abuse permissions fails
<img width="546" height="411" alt="image" src="https://github.com/user-attachments/assets/730c6f62-41e6-4755-9639-92d98b12beb6" />


### https://bugs.launchpad.net/landscape-client/+bug/2065879
```
python3 client-container.py --ip 10.38.167.231 --hostname landscape-server-noble --account-name onward --series jammy --ppas joey-mucci/client --client-name umask-test --register no
```

```
$ lxc exec umask-test -- bash -c "umask 027"
$ lxc exec umask-test -- sudo landscape-config --silent
2026-08-31 21:22:49,184 INFO     [MainThread] Sent 3598 bytes and received 200 bytes in 0.02s
Registration request sent successfully
```

### https://bugs.launchpad.net/landscape-client/+bug/2121558
```
$ lxc exec fresh-install -- ls -lah /var/lib/landscape/client
total 92K
drwxr-x--- 7 landscape landscape 4.0K Aug 31 21:25 .
drwxr-xr-x 3 landscape landscape 4.0K Aug 31 21:00 ..
drwxr-x--- 2 landscape landscape 4.0K Aug 31 21:00 annotations.d
-rw-r----- 1 landscape landscape 1.9K Aug 31 21:25 broker.bpickle
-rw-r----- 1 landscape landscape 1.9K Aug 31 21:25 broker.bpickle.old
drwxr-x--- 2 landscape landscape 4.0K Aug 31 21:00 custom-graph-scripts
-rw-r--r-- 1 landscape landscape    0 Aug 31 21:25 detect_package_changes_timestamp
-rw-r----- 1 landscape landscape  12K Aug 31 21:09 exchange.database
-rw-r----- 1 landscape landscape    2 Aug 31 21:25 keystone.bpickle
-rw-r----- 1 landscape landscape    2 Aug 31 21:20 keystone.bpickle.old
-rw-r----- 1 root      root       12K Aug 31 21:00 manager.database
drwxr-x--- 3 landscape landscape 4.0K Aug 31 21:01 messages
-rw-r----- 1 landscape landscape  12K Aug 31 21:25 monitor.bpickle
-rw-r----- 1 landscape landscape  12K Aug 31 21:24 monitor.bpickle.old
drwxr-x--- 5 landscape landscape 4.0K Aug 31 21:25 package
drwxr-x--- 2 landscape landscape 4.0K Aug 31 21:00 sockets
```

### Normal Functionality

Clients can still ping and run scripts, I didn't see any regressions here. Potential regressions are places where landscape-client depends on being able to write to `client.conf ` as Landscape. I don't see anywhere this could be an issue, beyond what has been tested. The landscape-client snap should run as root, so there isn't cause for concern there.