### PR TITLE
fix: reject unrecognized positional arguments in landscape-config (LP# 2028517)

### DIFF
--- a/landscape/client/configuration.py
+++ b/landscape/client/configuration.py
@@ -150,6 +150,12 @@ class LandscapeSetupConfiguration(BrokerConfiguration):
 
     encoding = "utf-8"
 
+    def load_command_line(self, args):
+        super().load_command_line(args)
+        if self._command_line_options.get("positional"):
+            extra = " ".join(self._command_line_options["positional"])
+            self._parser.error(f"unrecognized arguments: {extra}")
+
     def _load_external_options(self):
         """Handle the --import parameter.
 

--- a/landscape/client/tests/test_configuration.py
+++ b/landscape/client/tests/test_configuration.py
@@ -60,6 +60,17 @@ url = https://landscape.canonical.com/message-system
         config.load(args)
         return config
 
+    def test_positional_arguments_rejected(self):
+        """
+        Positional arguments (such as 'unregister') cause ArgumentParser
+        to exit with error code 2 instead of starting setup (LP: #2028517).
+        """
+        with mock.patch("sys.stderr", new_callable=StringIO) as stderr:
+            with self.assertRaises(SystemExit) as cm:
+                self.get_config(["unregister"])
+            self.assertEqual(cm.exception.code, 2)
+            self.assertIn("unrecognized arguments: unregister", stderr.getvalue())
+
 
 class PrintTextTest(LandscapeTest):
     @mock.patch("sys.stdout", new_callable=StringIO)


### PR DESCRIPTION
## Description
`landscape-config` previously accepted any unrecognized positional arguments (for example, typos or nonexistent subcommands like `landscape-config unregister`) and silently ignored them, proceeding to start the interactive configuration wizard instead of failing.

This happened because `BaseConfiguration.make_parser()` adds a catch-all positional argument `positional` (`nargs="*"`, `default=SUPPRESS`) to accommodate broker/manager/monitor daemons that pass `sys.argv`.

This PR overrides `load_command_line` in `LandscapeSetupConfiguration` to check whether unexpected positional arguments were parsed into `self._command_line_options["positional"]`, and invokes `self._parser.error(...)` to output an unrecognized argument error and exit with code 2.

Fixes: https://bugs.launchpad.net/landscape-client/+bug/2028517

## Testing
- Added unit test `test_positional_arguments_rejected` in `landscape/client/tests/test_configuration.py`.
- Verified behavior:
  - `landscape-config unregister` -> exits with code 2: `landscape-config: error: unrecognized arguments: unregister`
  - Valid options (`--help`, `--disable`, `--silent`, etc.) continue to work as expected.
- Ran test suite: `PYTHONPATH=. python3 -m landscape.lib.run_tests landscape.lib.tests.test_config landscape.client.tests.test_configuration` (179 tests PASSED).
- Ruff check and format pass cleanly.
