### PR TITLE
fix: route uaclient operations to data_path instead of $HOME (LP# 2146793)

### DIFF
--- a/landscape/client/broker/registration.py
+++ b/landscape/client/broker/registration.py
@@ -251,7 +251,10 @@ class RegistrationHandler:
         with_tags = f"and tags {tags} " if tags else ""
         with_group = f"in access group '{group}' " if group else ""
 
-        message["ubuntu_pro_info"] = json.dumps(get_ubuntu_pro_info())
+        data_path = getattr(self._config, "data_path", None) if self._config else None
+        message["ubuntu_pro_info"] = json.dumps(
+            get_ubuntu_pro_info(data_path=data_path)
+        )
 
         logging.info(
             f"Queueing message to register with account {account_name!r} "

--- a/landscape/client/manager/promanagement.py
+++ b/landscape/client/manager/promanagement.py
@@ -36,7 +36,12 @@ class ProManagement(ManagerPlugin):
         """
         opid = message["operation-id"]
         token = message["token"]
-        d = deferToThread(attach_pro, token)
+        data_path = (
+            getattr(self.config, "data_path", None)
+            if getattr(self, "config", None)
+            else None
+        )
+        d = deferToThread(attach_pro, token, data_path=data_path)
         d.addCallback(self._respond_success_attach, opid)
         d.addErrback(self._respond_failure, opid)
         return d
@@ -47,13 +52,27 @@ class ProManagement(ManagerPlugin):
         detaching a pro token.
         """
         opid = message["operation-id"]
-        d = deferToThread(detach_pro)
+        data_path = (
+            getattr(self.config, "data_path", None)
+            if getattr(self, "config", None)
+            else None
+        )
+        d = deferToThread(detach_pro, data_path=data_path)
         d.addCallback(self._respond_success_detach, opid)
         d.addErrback(self._respond_failure, opid)
         return d
 
     def _respond_success_attach(self, data, opid):
-        return self._respond(SUCCEEDED, json.dumps(get_ubuntu_pro_info()), opid)
+        data_path = (
+            getattr(self.config, "data_path", None)
+            if getattr(self, "config", None)
+            else None
+        )
+        return self._respond(
+            SUCCEEDED,
+            json.dumps(get_ubuntu_pro_info(data_path=data_path)),
+            opid,
+        )
 
     def _respond_success_detach(self, data, opid):
         return self._respond(SUCCEEDED, "Succeeded in detaching pro token.", opid)

--- a/landscape/client/manager/tests/test_ubuntuproinfo.py
+++ b/landscape/client/manager/tests/test_ubuntuproinfo.py
@@ -14,7 +14,7 @@ from landscape.client.tests.helpers import LandscapeTest, ManagerHelper
 
 
 def uastatus_mock_maker(ret_val):
-    def uastatus_mock(q):
+    def uastatus_mock(q, *args, **kwargs):
         q.put(ret_val)
 
     return uastatus_mock
@@ -83,6 +83,19 @@ class UbuntuProInfoTest(LandscapeTest):
             pro_info = q.get(timeout=30)
 
             self.assertEqual(self.mock_status_value, pro_info)
+
+    def test_uastatus_with_data_path(self):
+        mock.patch.stopall()
+        with mock.patch(
+            "landscape.client.manager.ubuntuproinfo.get_pro_status"
+        ) as mock_status:
+            mock_status.return_value = self.mock_status_value
+            q = self.ctx.Queue()
+            uastatus(q, data_path="/var/lib/landscape/client")
+            pro_info = q.get(timeout=30)
+
+            self.assertEqual(self.mock_status_value, pro_info)
+            mock_status.assert_called_once_with(data_path="/var/lib/landscape/client")
 
     def test_ubuntu_pro_info(self):
         """Tests calling `ua status`."""

--- a/landscape/client/manager/ubuntuproinfo.py
+++ b/landscape/client/manager/ubuntuproinfo.py
@@ -22,12 +22,16 @@ class UbuntuProInfo(DataWatcherManager):
     run_interval = 900  # 15 minutes
 
     def get_data(self):
-        ubuntu_pro_info = get_ubuntu_pro_info()
+        config = getattr(self, "config", None) or getattr(
+            getattr(self, "registry", None), "config", None
+        )
+        data_path = getattr(config, "data_path", None) if config else None
+        ubuntu_pro_info = get_ubuntu_pro_info(data_path=data_path)
         return json.dumps(ubuntu_pro_info, separators=(",", ":"), sort_keys=True)
 
 
-def uastatus(q):
-    pro_info = get_pro_status()
+def uastatus(q, data_path=None):
+    pro_info = get_pro_status(data_path=data_path)
     q.put(pro_info)
 
 
@@ -41,7 +45,7 @@ def serialize_datetimes(obj):
     return obj
 
 
-def get_ubuntu_pro_info() -> dict:
+def get_ubuntu_pro_info(data_path: str | None = None) -> dict:
     """Query ua tools for Ubuntu Pro status as JSON, parsing it to a dict.
 
     If we are running on Ubuntu Core, Pro does not exist.  Include a mocked
@@ -105,7 +109,7 @@ def get_ubuntu_pro_info() -> dict:
     else:
         ctx = multiprocessing.get_context("fork")
         q = ctx.Queue()
-        p = ctx.Process(target=uastatus, args=(q,))
+        p = ctx.Process(target=uastatus, args=(q, data_path))
         p.start()
         p.join()
 

--- a/landscape/client/registration.py
+++ b/landscape/client/registration.py
@@ -55,7 +55,9 @@ class ClientRegistrationInfo:
             hostname=get_fqdn(),
             registration_password=identity.registration_key,
             tags=identity.tags,
-            ubuntu_pro_info=json.dumps(get_ubuntu_pro_info()),
+            ubuntu_pro_info=json.dumps(
+                get_ubuntu_pro_info(data_path=getattr(identity, "data_path", None))
+            ),
             vm_info=get_vm_info(),
             machine_id=get_namespaced_machine_id(),
         )

--- a/landscape/client/tests/helpers.py
+++ b/landscape/client/tests/helpers.py
@@ -63,7 +63,7 @@ class MessageTestCase(unittest.TestCase):
             )
 
 
-def fake_pro_info_func(q):
+def fake_pro_info_func(q, *args, **kwargs):
     q.put({})
 
 

--- a/landscape/client/tests/test_uaclient.py
+++ b/landscape/client/tests/test_uaclient.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from unittest import TestCase, mock
 
@@ -12,6 +13,7 @@ from landscape.client.uaclient import (
     attach_pro,
     detach_pro,
     get_pro_status,
+    uaclient_environment,
 )
 
 if not IS_SNAP and not IS_CORE:
@@ -147,3 +149,34 @@ class TestUAClientWrapper(TestCase):
             mock_is_attached.return_value = FakeIsAttached(is_attached=False)
             with self.assertRaises(ProNotAttachedError):
                 detach_pro()
+
+    @mock.patch("landscape.client.uaclient.status")
+    @mock.patch("landscape.client.uaclient.UAConfig")
+    def test_get_pro_status_with_data_path(self, mock_uaconfig, mock_status):
+        mock_uaconfig.return_value = None
+
+        def check_env(config):
+            self.assertEqual(
+                os.environ.get("XDG_CACHE_HOME"),
+                os.path.join("/tmp/test_data_path", "cache"),
+            )
+            return self.mock_status_value
+
+        mock_status.side_effect = check_env
+
+        pro_status = get_pro_status(data_path="/tmp/test_data_path")
+        self.assertEqual(self.mock_status_value, pro_status)
+        self.assertNotEqual(
+            os.environ.get("XDG_CACHE_HOME"),
+            os.path.join("/tmp/test_data_path", "cache"),
+        )
+
+    def test_uaclient_environment_restores_env(self):
+        test_data_path = "/tmp/test_landscape_data"
+        expected_cache = os.path.join(test_data_path, "cache")
+        orig_xdg = os.environ.get("XDG_CACHE_HOME")
+
+        with uaclient_environment(test_data_path):
+            self.assertEqual(os.environ.get("XDG_CACHE_HOME"), expected_cache)
+
+        self.assertEqual(os.environ.get("XDG_CACHE_HOME"), orig_xdg)

--- a/landscape/client/uaclient.py
+++ b/landscape/client/uaclient.py
@@ -6,6 +6,9 @@ safety checks to ensure we are allowed to use the uaclient methods.
 """
 
 import logging
+import os
+import tempfile
+from contextlib import contextmanager
 
 from landscape.client.environment import IS_CORE, IS_SNAP
 
@@ -70,29 +73,70 @@ UACLIENT_ERROR_MESSAGE = (
 )
 
 
-def get_pro_status():
+@contextmanager
+def uaclient_environment(data_path: str | None = None):
+    """Ensure XDG_CACHE_HOME (and HOME if needed) points to a writable
+    location (such as Landscape's data_path) so uaclient does not attempt
+    to write cache files to an inaccessible user home directory.
+    """
+    cache_dir = None
+    if data_path:
+        cache_dir = os.path.join(data_path, "cache")
+    elif not os.environ.get("XDG_CACHE_HOME"):
+        default_dir = "/var/lib/landscape/client"
+        if os.path.isdir(default_dir) and os.access(default_dir, os.W_OK):
+            cache_dir = os.path.join(default_dir, "cache")
+        else:
+            cache_dir = os.path.join(tempfile.gettempdir(), "landscape-cache")
+
+    orig_xdg = os.environ.get("XDG_CACHE_HOME")
+    orig_home = os.environ.get("HOME")
+    try:
+        if cache_dir:
+            try:
+                os.makedirs(cache_dir, exist_ok=True)
+            except OSError:
+                pass
+            os.environ["XDG_CACHE_HOME"] = cache_dir
+        if data_path and (orig_home is None or not os.access(orig_home, os.W_OK)):
+            os.environ["HOME"] = data_path
+        yield
+    finally:
+        if orig_xdg is not None:
+            os.environ["XDG_CACHE_HOME"] = orig_xdg
+        elif cache_dir and "XDG_CACHE_HOME" in os.environ:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        if orig_home is not None:
+            os.environ["HOME"] = orig_home
+        elif data_path and "HOME" in os.environ and orig_home is None:
+            os.environ.pop("HOME", None)
+
+
+def get_pro_status(data_path: str | None = None):
     """Calls uaclient.status to get pro information."""
     if uaclient is None:
         logging.warning(UACLIENT_ERROR_MESSAGE)
         return {}
     try:
-        config = UAConfig()
-        pro_info = status(config)
-        return pro_info
+        with uaclient_environment(data_path):
+            config = UAConfig()
+            pro_info = status(config)
+            return pro_info
     except Exception:
         logging.warning("Could not get pro information for computer.")
         return {}
 
 
-def attach_pro(token):
+def attach_pro(token, data_path: str | None = None):
     """Attaches a pro token to current machine."""
     if uaclient is None:
         logging.warning(UACLIENT_ERROR_MESSAGE)
         raise ProManagementError(UACLIENT_ERROR_MESSAGE)
 
     try:
-        options = FullTokenAttachOptions(token=token, auto_enable_services=False)
-        full_token_attach(options)
+        with uaclient_environment(data_path):
+            options = FullTokenAttachOptions(token=token, auto_enable_services=False)
+            full_token_attach(options)
     except AttachInvalidTokenError:
         raise InvalidTokenException
     except ConnectivityError:
@@ -105,16 +149,17 @@ def attach_pro(token):
         raise ProManagementError
 
 
-def detach_pro():
+def detach_pro(data_path: str | None = None):
     if uaclient is None:
         logging.warning(UACLIENT_ERROR_MESSAGE)
         raise ProManagementError(UACLIENT_ERROR_MESSAGE)
 
     try:
-        result = is_attached()
-        if not result.is_attached:
-            raise ProNotAttachedError
+        with uaclient_environment(data_path):
+            result = is_attached()
+            if not result.is_attached:
+                raise ProNotAttachedError
 
-        detach()
+            detach()
     except UbuntuProError:
         raise ProManagementError


### PR DESCRIPTION
## Description

When interacting with Ubuntu Pro via `uaclient` (such as querying Pro status via `get_pro_status` or during client registration), `uaclient.system.get_user_cache_dir()` writes user cache files (e.g. `livepatch-kernel-support-cache.json`) to `$XDG_CACHE_HOME/ubuntu-pro` or `$HOME/.cache/ubuntu-pro`.

When `landscape-client` runs as a daemon or under environments where the user's `$HOME` is non-existent, inaccessible, or restricted (e.g., AD/LDAP accounts, service users with `HOME=/nonexistent`), `uaclient` raises `PermissionError: [Errno 13] Permission denied: '/nonexistent'`. As a result, Ubuntu Pro status detection fails or Pro information cannot be gathered during registration.

This PR addresses the issue by routing `uaclient` cache and environment operations to Landscape's configured `data_path` (or its `cache` subdirectory) instead of relying on `$HOME`.

## Changes

1. **`landscape/client/uaclient.py`**:
   - Introduced `uaclient_environment(data_path: str | None = None)` context manager.
   - When `data_path` is provided, temporarily sets `XDG_CACHE_HOME` to `os.path.join(data_path, "cache")` (ensuring the directory exists).
   - If `$HOME` is missing, empty, or points to a non-existent path, temporarily points `HOME` to `data_path`.
   - Restores the original environment variables (`XDG_CACHE_HOME`, `HOME`) in a `finally` block.
   - Wrapped `get_pro_status`, `attach_pro`, and `detach_pro` with `uaclient_environment(data_path)`.

2. **Propagate `data_path`**:
   - `landscape/client/manager/ubuntuproinfo.py`: `UbuntuProInfo.get_data` and `get_ubuntu_pro_info` forward `data_path` from configuration to `uastatus`.
   - `landscape/client/broker/registration.py`: passes `data_path` from broker configuration when gathering `ubuntu_pro_info`.
   - `landscape/client/registration.py`: `ClientRegistrationInfo.from_identity` forwards `data_path` from identity.
   - `landscape/client/manager/promanagement.py`: passes `data_path` to `attach_pro` and `detach_pro`.

3. **Tests**:
   - Added unit tests in `landscape/client/tests/test_uaclient.py` testing `uaclient_environment` environment management and restoration.
   - Added unit test in `landscape/client/manager/tests/test_ubuntuproinfo.py` testing `uastatus` with `data_path`.
   - Updated test helpers in `landscape/client/tests/helpers.py` and `test_ubuntuproinfo.py` to accept arguments.
   - Verified that all 1583 unit tests in `landscape.client` pass.

Fixes: [LP# 2146793](https://bugs.launchpad.net/landscape-client/+bug/2146793)
